### PR TITLE
Adjust openshift configuration values

### DIFF
--- a/values.openshift.yaml
+++ b/values.openshift.yaml
@@ -6,19 +6,6 @@
 global:
   openshift: true
 
-injector:
-  image:
-    repository: "registry.connect.redhat.com/hashicorp/vault-k8s"
-    tag: "1.4.1-ubi"
-
-  agentImage:
-    repository: "registry.connect.redhat.com/hashicorp/vault"
-    tag: "1.16.1-ubi"
-
 server:
-  image:
-    repository: "registry.connect.redhat.com/hashicorp/vault"
-    tag: "1.16.1-ubi"
-
   readinessProbe:
     path: "/v1/sys/health?uninitcode=204"


### PR DESCRIPTION
We are using the same image for both deployments. These values are used during chart verification. The images need to be RedHat certified. This is what causes the test failure. This will be fixed in a different PR (update-4), that needs to be rebased after the removal of all the other stuff.