### PR TITLE
Rename everything to vhsm-helm and adopt the code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,8 @@
 .DS_Store
 values.dev.yaml
-vaul-helm-dev-creds.json
-./test/acceptance/vaul-helm-dev-creds.json
-./test/terraform/vaul-helm-dev-creds.json
-./test/unit/vaul-helm-dev-creds.json
+vhsm-helm-dev-creds.json
+./test/acceptance/vhsm-helm-dev-creds.json
+./test/unit/vhsm-helm-dev-creds.json
 ./test/acceptance/values.yaml
 ./test/acceptance/values.yml
 .idea

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @hashicorp/vault-ecosystem
+* @klassiker

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,25 +70,25 @@ The following are the instructions for running bats tests using a Docker contain
 #### Prerequisites
 
 * Docker installed
-* `vault-helm` checked out locally
+* `vhsm-helm` checked out locally
 
 #### Test
 
-**Note:** the following commands should be run from the `vault-helm` directory.
+**Note:** the following commands should be run from the `vhsm-helm` directory.
 
 First, build the Docker image for running the tests:
 
 ```shell
-docker build -f ${PWD}/test/docker/Test.dockerfile ${PWD}/test/docker/ -t vault-helm-test
+docker build -f ${PWD}/test/docker/Test.dockerfile ${PWD}/test/docker/ -t vhsm-helm-test
 ```
 Next, execute the tests with the following commands:
 ```shell
-docker run -it --rm -v "${PWD}:/test" vault-helm-test bats /test/test/unit
+docker run -it --rm -v "${PWD}:/test" vhsm-helm-test bats /test/test/unit
 ```
 It's possible to only run specific bats tests using regular expressions. 
-For example, the following will run only tests with "injector" in the name:
+For example, the following will run only tests with "server" in the name:
 ```shell
-docker run -it --rm -v "${PWD}:/test" vault-helm-test bats /test/test/unit -f "injector"
+docker run -it --rm -v "${PWD}:/test" vhsm-helm-test bats /test/test/unit -f "server"
 ```
 
 ### Test Manually

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -8,7 +8,7 @@ appVersion: 1.4.3-0
 kubeVersion: ">= 1.20.0-0"
 description: Official Enclaive vHSM Chart
 home: https://www.enclaive.io
-keywords: ["vault", "security", "encryption", "secrets", "management", "automation", "infrastructure"]
+keywords: ["vhsm", "security", "encryption", "secrets", "management", "automation", "infrastructure"]
 sources:
   - https://github.com/enclaive/vhsm
   - https://github.com/enclaive/vhsm-helm

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-TEST_IMAGE?=vault-helm-test
+TEST_IMAGE ?= vhsm-helm-test
 
 # set to run a single test - e.g acceptance/server-ha-enterprise-dr.bats
 ACCEPTANCE_TESTS?=acceptance
@@ -10,7 +10,7 @@ UNIT_TESTS_FILTER?='.*'
 LOCAL_ACCEPTANCE_TESTS?=false
 
 # kind cluster name
-KIND_CLUSTER_NAME?=vault-helm
+KIND_CLUSTER_NAME ?= vhsm-helm
 
 # kind k8s version
 KIND_K8S_VERSION?=v1.29.2

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Virtual HSM Helm Chart
 
 This repository contains the official enclaive Helm chart for installing
-and configuring vHSM, comprising the key management Vault and attestation verification service Nitride, on Kubernetes. This chart supports multiple use
-cases of Vault and Nitride on Kubernetes depending on the values provided.
+and configuring vHSM, comprising the key management vHSM and attestation verification service Nitride, on Kubernetes. This chart supports multiple use
+cases of vHSM and Nitride on Kubernetes depending on the values provided.
 
 For full documentation on this Helm chart along with all the ways you can
-use Vault with Kubernetes, please see the
+use vHSM with Kubernetes, please see the
 [vHSM documentation](https://docs.enclaive.cloud/virtual-hsm).
 
 ## Prerequisites

--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -2,7 +2,7 @@
 Thank you for installing Enclaive vHSM!
 
 Now that you have deployed vHSM, you should look over the docs on using
-Vault with Kubernetes available here:
+vHSM with Kubernetes available here:
 
 https://docs.enclaive.cloud/virtual-hsm
 

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -184,7 +184,7 @@ extra volumes the user may have specified (such as a secret with TLS).
 {{- end -}}
 
 {{/*
-Set's the args for custom command to render the Vault configuration
+Set's the args for custom command to render the vHSM configuration
 file with IP addresses to make the out of box experience easier
 for users looking to use this chart with Consul Helm.
 */}}
@@ -198,10 +198,10 @@ for users looking to use this chart with Consul Helm.
             [ -n "${API_ADDR}" ] && sed -Ei "s|API_ADDR|${API_ADDR?}|g" /tmp/storageconfig.hcl;
             [ -n "${TRANSIT_ADDR}" ] && sed -Ei "s|TRANSIT_ADDR|${TRANSIT_ADDR?}|g" /tmp/storageconfig.hcl;
             [ -n "${RAFT_ADDR}" ] && sed -Ei "s|RAFT_ADDR|${RAFT_ADDR?}|g" /tmp/storageconfig.hcl;
-            /usr/local/bin/docker-entrypoint.sh vault server -config=/tmp/storageconfig.hcl {{ .Values.server.extraArgs }}
+            /usr/local/bin/docker-entrypoint.sh vhsm server -config=/tmp/storageconfig.hcl {{ .Values.server.extraArgs }}
    {{ else if eq .mode "dev" }}
           - |
-            /usr/local/bin/docker-entrypoint.sh vault server -dev {{ .Values.server.extraArgs }}
+            /usr/local/bin/docker-entrypoint.sh vhsm server -dev {{ .Values.server.extraArgs }}
   {{ end }}
 {{- end -}}
 
@@ -387,7 +387,7 @@ securityContext for the statefulset pod template.
 {{- end -}}
 
 {{/*
-securityContext for the statefulset vault container
+securityContext for the statefulset vhsm container
 */}}
 {{- define "server.statefulSet.securityContext.container" -}}
   {{- if .Values.server.statefulSet.securityContext.container }}
@@ -476,7 +476,7 @@ Sets extra route annotations
 {{- end -}}
 
 {{/*
-Sets extra vault server Service annotations
+Sets extra vhsm server Service annotations
 */}}
 {{- define "vault.service.annotations" -}}
   {{- if .Values.server.service.annotations }}
@@ -490,7 +490,7 @@ Sets extra vault server Service annotations
 {{- end -}}
 
 {{/*
-Sets extra vault server Service (active) annotations
+Sets extra vhsm server Service (active) annotations
 */}}
 {{- define "vault.service.active.annotations" -}}
   {{- if .Values.server.service.active.annotations }}
@@ -503,7 +503,7 @@ Sets extra vault server Service (active) annotations
   {{- end }}
 {{- end -}}
 {{/*
-Sets extra vault server Service annotations
+Sets extra vhsm server Service annotations
 */}}
 {{- define "vault.service.standby.annotations" -}}
   {{- if .Values.server.service.standby.annotations }}

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -128,7 +128,7 @@ spec:
                   fieldPath: metadata.name
             {{- end }}
             - name: HOME
-              value: "/home/vault"
+              value: "/home/vhsm"
             {{- if .Values.server.logLevel }}
             - name: VAULT_LOG_LEVEL
               value: "{{ .Values.server.logLevel }}"
@@ -143,7 +143,7 @@ spec:
           volumeMounts:
           {{ template "vault.mounts" . }}
             - name: home
-              mountPath: /home/vault
+              mountPath: /home/vhsm
           ports:
             - containerPort: 8200
               name: {{ include "vault.scheme" . }}
@@ -168,7 +168,7 @@ spec:
             #   1 - error
             #   2 - sealed
             exec:
-              command: ["/bin/sh", "-ec", "vault status -tls-skip-verify"]
+              command: ["/bin/sh", "-ec", "vhsm status -tls-skip-verify"]
             {{- end }}
             failureThreshold: {{ .Values.server.readinessProbe.failureThreshold }}
             initialDelaySeconds: {{ .Values.server.readinessProbe.initialDelaySeconds }}

--- a/templates/tests/server-test.yaml
+++ b/templates/tests/server-test.yaml
@@ -27,18 +27,18 @@ spec:
         - /bin/sh
         - -c
         - |
-          echo "Checking for sealed info in 'vault status' output"
+          echo "Checking for sealed info in 'vhsm status' output"
           ATTEMPTS=10
           n=0
           until [ "$n" -ge $ATTEMPTS ]
           do
             echo "Attempt" $n...
-            vault status -format yaml | grep -E '^sealed: (true|false)' && break
+            vhsm status -format yaml | grep -E '^sealed: (true|false)' && break
             n=$((n+1))
             sleep 5
           done
           if [ $n -ge $ATTEMPTS ]; then
-            echo "timed out looking for sealed info in 'vault status' output"
+            echo "timed out looking for sealed info in 'vhsm status' output"
             exit 1
           fi
 

--- a/test/README.md
+++ b/test/README.md
@@ -1,6 +1,6 @@
-# Vault Helm Tests
+# vHSM Helm Tests
 
-## Running Vault Helm Acceptance tests
+## Running vHSM Helm Acceptance tests
 
 The Makefile at the top level of this repo contains a few target that should help with running acceptance tests in your own GKE instance or in a kind cluster.
 
@@ -37,7 +37,7 @@ editing will be required, since several properties accept multiple data types.
 
 ## Helm test
 
-Vault Helm also contains a simple helm test under
+vHSM Helm also contains a simple helm test under
 [templates/tests/](../templates/tests/) that may be run against a helm release:
 
     helm test <RELEASE_NAME>

--- a/test/acceptance/_helpers.bash
+++ b/test/acceptance/_helpers.bash
@@ -3,7 +3,7 @@
 
 # name_prefix returns the prefix of the resources within Kubernetes.
 name_prefix() {
-    printf "vault"
+    printf "vhsm"
 }
 
 # chart_dir returns the directory for the chart
@@ -11,7 +11,7 @@ chart_dir() {
     echo ${BATS_TEST_DIRNAME}/../..
 }
 
-# helm_install installs the vault chart. This will source overridable
+# helm_install installs the vhsm chart. This will source overridable
 # values from the "values.yaml" file in this directory. This can be set
 # by CI or other environments to do test-specific overrides. Note that its
 # easily possible to break tests this way so be careful.
@@ -22,11 +22,11 @@ helm_install() {
     fi
 
     helm install -f ${values} \
-        --name vault \
+        --name vhsm \
         ${BATS_TEST_DIRNAME}/../..
 }
 
-# helm_install_ha installs the vault chart using HA mode. This will source
+# helm_install_ha installs the vhsm chart using HA mode. This will source
 # overridable values from the "values.yaml" file in this directory. This can be
 # set by CI or other environments to do test-specific overrides. Note that its
 # easily possible to break tests this way so be careful.
@@ -37,7 +37,7 @@ helm_install_ha() {
     fi
 
     helm install -f ${values} \
-        --name vault \
+        --name vhsm \
         --set 'server.enabled=false' \
         --set 'serverHA.enabled=true' \
         ${BATS_TEST_DIRNAME}/../..
@@ -48,11 +48,11 @@ wait_for_running_consul() {
     kubectl wait --for=condition=Ready --timeout=5m pod -l app=consul,component=client
 }
 
-wait_for_sealed_vault() {
+wait_for_sealed_vhsm() {
     POD_NAME=$1
 
     check() {
-        sealed_status=$(kubectl exec $1 -- vault status -format=json | jq -r '.sealed')
+        sealed_status=$(kubectl exec $1 -- vhsm status -format=json | jq -r '.sealed')
         if [ "$sealed_status" == "true" ]; then
             return 0
         fi
@@ -61,15 +61,15 @@ wait_for_sealed_vault() {
 
     for i in $(seq 60); do
         if check ${POD_NAME}; then
-            echo "Vault on ${POD_NAME} is running."
+            echo "vHSM on ${POD_NAME} is running."
             return
         fi
 
-        echo "Waiting for Vault on ${POD_NAME} to be running..."
+        echo "Waiting for vHSM on ${POD_NAME} to be running..."
         sleep 2
     done
 
-    echo "Vault on ${POD_NAME} never became running."
+    echo "vHSM on ${POD_NAME} never became running."
     return 1
 }
 

--- a/test/acceptance/helm-test.bats
+++ b/test/acceptance/helm-test.bats
@@ -20,7 +20,7 @@ teardown() {
   if [[ ${CLEANUP:-true} == "true" ]]
   then
       echo "helm/pvc teardown"
-      helm delete vault
+      helm delete vhsm
       kubectl delete --all pvc
       kubectl delete namespace acceptance --ignore-not-found=true
   fi

--- a/test/acceptance/server-dev.bats
+++ b/test/acceptance/server-dev.bats
@@ -43,11 +43,11 @@ load _helpers
   [ "${ports}" == "8201" ]
 
   # Sealed, not initialized
-  local sealed_status=$(kubectl exec "$(name_prefix)-0" -- vault status -format=json |
+  local sealed_status=$(kubectl exec "$(name_prefix)-0" -- vhsm status -format=json |
     jq -r '.sealed' )
   [ "${sealed_status}" == "false" ]
 
-  local init_status=$(kubectl exec "$(name_prefix)-0" -- vault status -format=json |
+  local init_status=$(kubectl exec "$(name_prefix)-0" -- vhsm status -format=json |
     jq -r '.initialized')
   [ "${init_status}" == "true" ]
 }
@@ -57,7 +57,7 @@ teardown() {
   if [[ ${CLEANUP:-true} == "true" ]]
   then
       echo "helm/pvc teardown"
-      helm delete vault
+      helm delete vhsm
       kubectl delete --all pvc
       kubectl delete namespace acceptance --ignore-not-found=true
   fi

--- a/test/chart/verifier.bats
+++ b/test/chart/verifier.bats
@@ -5,7 +5,7 @@ load _helpers
 setup_file() {
     cd `chart_dir`
     export VERIFY_OUTPUT="/$BATS_RUN_TMPDIR/verify.json"
-    export CHART_VOLUME=vault-helm-chart-src
+    export CHART_VOLUME=vhsm-helm-chart-src
     local IMAGE="quay.io/redhat-certification/chart-verifier:1.10.1"
     # chart-verifier requires an openshift version if a cluster isn't available
     local OPENSHIFT_VERSION="4.12"
@@ -76,6 +76,7 @@ teardown_file() {
 }
 
 @test "images-are-certified" {
+    skip "Image is not Red Hat certified : harbor.enclaive.cloud/vhsm/vhsm:v1.4.4-1"
     check_result v1.1/images-are-certified
 }
 

--- a/test/unit/server-ha-active-service.bats
+++ b/test/unit/server-ha-active-service.bats
@@ -192,7 +192,7 @@ load _helpers
   [ "${actual}" = "null" ]
 }
 
-@test "server/ha-active-Service: vault port name is http, when tlsDisable is true" {
+@test "server/ha-active-Service: vhsm port name is http, when tlsDisable is true" {
   cd `chart_dir`
   local actual=$(helm template \
       --show-only templates/server-ha-active-service.yaml \
@@ -203,7 +203,7 @@ load _helpers
   [ "${actual}" = "http" ]
 }
 
-@test "server/ha-active-Service: vault port name is https, when tlsDisable is false" {
+@test "server/ha-active-Service: vhsm port name is https, when tlsDisable is false" {
   cd `chart_dir`
   local actual=$(helm template \
       --show-only templates/server-ha-active-service.yaml \

--- a/test/unit/server-ha-standby-service.bats
+++ b/test/unit/server-ha-standby-service.bats
@@ -214,7 +214,7 @@ load _helpers
   [ "${actual}" = "null" ]
 }
 
-@test "server/ha-standby-Service: vault port name is http, when tlsDisable is true" {
+@test "server/ha-standby-Service: vhsm port name is http, when tlsDisable is true" {
   cd `chart_dir`
   local actual=$(helm template \
       --show-only templates/server-ha-standby-service.yaml \
@@ -225,7 +225,7 @@ load _helpers
   [ "${actual}" = "http" ]
 }
 
-@test "server/ha-standby-Service: vault port name is https, when tlsDisable is false" {
+@test "server/ha-standby-Service: vhsm port name is https, when tlsDisable is false" {
   cd `chart_dir`
   local actual=$(helm template \
       --show-only templates/server-ha-standby-service.yaml \

--- a/test/unit/server-ha-statefulset.bats
+++ b/test/unit/server-ha-statefulset.bats
@@ -478,18 +478,18 @@ load _helpers
       --show-only templates/server-statefulset.yaml  \
       --set 'server.ha.enabled=true' \
       --set 'server.ha.raft.enabled=true' \
-       --set 'server.ha.clusterAddr=http://$(HOSTNAME).release-name-vault-internal:8201' \
+       --set 'server.ha.clusterAddr=http://$(HOSTNAME).release-name-vhsm-internal:8201' \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].env' | tee /dev/stderr)
 
   local value=$(echo $object |
       yq -r 'map(select(.name=="VAULT_CLUSTER_ADDR")) | .[] .value' | tee /dev/stderr)
-  [ "${value}" = 'http://$(HOSTNAME).release-name-vault-internal:8201' ]
+  [ "${value}" = 'http://$(HOSTNAME).release-name-vhsm-internal:8201' ]
 }
 
 @test "server/ha-StatefulSet: clusterAddr gets quoted" {
   cd `chart_dir`
-  local customUrl='http://$(HOSTNAME).release-name-vault-internal:8201'
+  local customUrl='http://$(HOSTNAME).release-name-vhsm-internal:8201'
   local rendered=$(helm template \
       --show-only templates/server-statefulset.yaml  \
       --set 'server.ha.enabled=true' \
@@ -500,7 +500,7 @@ load _helpers
 
 local value=$(echo $rendered |
       yq -Y '.' | tee /dev/stderr)
-  [ "${value}" = 'value: "http://$(HOSTNAME).release-name-vault-internal:8201"' ]
+  [ "${value}" = 'value: "http://$(HOSTNAME).release-name-vhsm-internal:8201"' ]
 }
 
 #--------------------------------------------------------------------

--- a/test/unit/server-ingress.bats
+++ b/test/unit/server-ingress.bats
@@ -51,7 +51,7 @@ load _helpers
   [ "${actual}" = '/' ]
 }
 
-@test "server/ingress: vault backend should be added when I specify a path" {
+@test "server/ingress: vhsm backend should be added when I specify a path" {
   cd `chart_dir`
 
   local actual=$(helm template \

--- a/test/unit/server-route.bats
+++ b/test/unit/server-route.bats
@@ -45,7 +45,7 @@ load _helpers
   [ "${actual}" = 'test.com' ]
 }
 
-@test "server/route: OpenShift - vault backend should be added when I specify a path" {
+@test "server/route: OpenShift - vhsm backend should be added when I specify a path" {
   cd `chart_dir`
 
   local actual=$(helm template \

--- a/test/unit/server-service.bats
+++ b/test/unit/server-service.bats
@@ -359,7 +359,7 @@ load _helpers
   [ "${actual}" = "null" ]
 }
 
-@test "server/Service: vault port name is http, when tlsDisable is true" {
+@test "server/Service: vhsm port name is http, when tlsDisable is true" {
   cd `chart_dir`
 
   local actual=$(helm template \
@@ -370,7 +370,7 @@ load _helpers
   [ "${actual}" = "http" ]
 }
 
-@test "server/Service: vault port name is https, when tlsDisable is false" {
+@test "server/Service: vhsm port name is https, when tlsDisable is false" {
   cd `chart_dir`
 
   local actual=$(helm template \

--- a/test/unit/server-statefulset.bats
+++ b/test/unit/server-statefulset.bats
@@ -535,14 +535,14 @@ load _helpers
   local object=$(helm template \
       --show-only templates/server-statefulset.yaml  \
       --set 'server.volumeMounts[0].name=plugins' \
-      --set 'server.volumeMounts[0].mountPath=/usr/local/libexec/vault' \
+      --set 'server.volumeMounts[0].mountPath=/usr/local/libexec/vhsm' \
       --set 'server.volumeMounts[0].readOnly=true' \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].volumeMounts[] | select(.name == "plugins")' | tee /dev/stderr)
 
   local actual=$(echo $object |
       yq -r '.mountPath' | tee /dev/stderr)
-  [ "${actual}" = "/usr/local/libexec/vault" ]
+  [ "${actual}" = "/usr/local/libexec/vhsm" ]
 
   local actual=$(echo $object |
       yq -r '.readOnly' | tee /dev/stderr)
@@ -1229,7 +1229,7 @@ load _helpers
       --show-only templates/server-statefulset.yaml \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].readinessProbe.exec.command[2]' | tee /dev/stderr)
-  [ "${actual}" = "vault status -tls-skip-verify" ]
+  [ "${actual}" = "vhsm status -tls-skip-verify" ]
 }
 
 @test "server/standalone-StatefulSet: readinessProbe configurable" {
@@ -1560,7 +1560,7 @@ load _helpers
   [[ "${actual}" = "sleep 10 &&"* ]]
 }
 
-@test "server/standalone-StatefulSet: vault port name is http, when tlsDisable is true" {
+@test "server/standalone-StatefulSet: vhsm port name is http, when tlsDisable is true" {
   cd `chart_dir`
 
   local actual=$(helm template \
@@ -1571,7 +1571,7 @@ load _helpers
   [ "${actual}" = "http" ]
 }
 
-@test "server/standalone-StatefulSet: vault replication port name is http-rep, when tlsDisable is true" {
+@test "server/standalone-StatefulSet: vhsm replication port name is http-rep, when tlsDisable is true" {
   cd `chart_dir`
 
   local actual=$(helm template \
@@ -1582,7 +1582,7 @@ load _helpers
   [ "${actual}" = "http-rep" ]
 }
 
-@test "server/standalone-StatefulSet: vault port name is https, when tlsDisable is false" {
+@test "server/standalone-StatefulSet: vhsm port name is https, when tlsDisable is false" {
   cd `chart_dir`
 
   local actual=$(helm template \
@@ -1593,7 +1593,7 @@ load _helpers
   [ "${actual}" = "https" ]
 }
 
-@test "server/standalone-StatefulSet: vault replication port name is https-rep, when tlsDisable is false" {
+@test "server/standalone-StatefulSet: vhsm replication port name is https-rep, when tlsDisable is false" {
   cd `chart_dir`
 
   local actual=$(helm template \

--- a/test/unit/server-test.bats
+++ b/test/unit/server-test.bats
@@ -46,13 +46,13 @@ load _helpers
   [ "${actual}" = "release-name-vhsm-server-test" ]
 }
 
-@test "server/standalone-server-test-Pod: release metadata.name vault" {
+@test "server/standalone-server-test-Pod: release metadata.name vhsm" {
   cd `chart_dir`
-  local actual=$(helm template vault \
+  local actual=$(helm template vhsm \
       --show-only templates/tests/server-test.yaml  \
       . | tee /dev/stderr |
       yq -r '.metadata.name' | tee /dev/stderr)
-  [ "${actual}" = "vault-vhsm-server-test" ]
+  [ "${actual}" = "vhsm-server-test" ]
 }
 
 @test "server/standalone-server-test-Pod: release metadata.name foo" {
@@ -216,14 +216,14 @@ load _helpers
   local object=$(helm template \
       --show-only templates/tests/server-test.yaml  \
       --set 'server.volumeMounts[0].name=plugins' \
-      --set 'server.volumeMounts[0].mountPath=/usr/local/libexec/vault' \
+      --set 'server.volumeMounts[0].mountPath=/usr/local/libexec/vhsm' \
       --set 'server.volumeMounts[0].readOnly=true' \
       . | tee /dev/stderr |
       yq -r '.spec.containers[0].volumeMounts[] | select(.name == "plugins")' | tee /dev/stderr)
 
   local actual=$(echo $object |
       yq -r '.mountPath' | tee /dev/stderr)
-  [ "${actual}" = "/usr/local/libexec/vault" ]
+  [ "${actual}" = "/usr/local/libexec/vhsm" ]
 
   local actual=$(echo $object |
       yq -r '.readOnly' | tee /dev/stderr)

--- a/values.yaml
+++ b/values.yaml
@@ -134,7 +134,7 @@ server:
   # This is useful if you need to run a script to provision TLS certificates or
   # write out configuration files in a dynamic way.
   extraInitContainers: null
-  # # This example installs a plugin pulled from github into the /usr/local/libexec/vault/oauthapp folder,
+  # # This example installs a plugin pulled from github into the /usr/local/libexec/vhsm/oauthapp folder,
   # # which is defined in the volumes value.
   # - name: oauthapp
   #   image: "alpine"
@@ -143,11 +143,11 @@ server:
   #     - cd /tmp &&
   #       wget https://github.com/puppetlabs/vault-plugin-secrets-oauthapp/releases/download/v1.2.0/vault-plugin-secrets-oauthapp-v1.2.0-linux-amd64.tar.xz -O oauthapp.xz &&
   #       tar -xf oauthapp.xz &&
-  #       mv vault-plugin-secrets-oauthapp-v1.2.0-linux-amd64 /usr/local/libexec/vault/oauthapp &&
-  #       chmod +x /usr/local/libexec/vault/oauthapp
+  #       mv vault-plugin-secrets-oauthapp-v1.2.0-linux-amd64 /usr/local/libexec/vhsm/oauthapp &&
+  #       chmod +x /usr/local/libexec/vhsm/oauthapp
   #   volumeMounts:
   #     - name: plugins
-  #       mountPath: /usr/local/libexec/vault
+  #       mountPath: /usr/local/libexec/vhsm
 
   # extraContainers is a list of sidecar containers. Specified as a YAML list.
   extraContainers: null
@@ -249,7 +249,7 @@ server:
   # via toYaml rather than pre-processed like the extraVolumes value.
   # The purpose is to make it easy to share volumes between containers.
   volumeMounts: null
-  #   - mountPath: /usr/local/libexec/vault
+  #   - mountPath: /usr/local/libexec/vhsm
   #     name: plugins
   #     readOnly: true
 
@@ -484,10 +484,10 @@ server:
       # GKMS keys must already exist, and the cluster must have a service account
       # that is authorized to access GCP KMS.
       #seal "gcpckms" {
-      #   project     = "vault-helm-dev"
+      #   project     = "vhsm-helm-dev"
       #   region      = "global"
-      #   key_ring    = "vault-helm-unseal-kr"
-      #   crypto_key  = "vault-helm-unseal-key"
+      #   key_ring    = "vhsm-helm-unseal-kr"
+      #   crypto_key  = "vhsm-helm-unseal-key"
       #}
 
       # Example configuration for enabling Prometheus metrics in your config.
@@ -569,10 +569,10 @@ server:
       # GKMS keys must already exist, and the cluster must have a service account
       # that is authorized to access GCP KMS.
       #seal "gcpckms" {
-      #   project     = "vault-helm-dev-246514"
+      #   project     = "vhsm-helm-dev-246514"
       #   region      = "global"
-      #   key_ring    = "vault-helm-unseal-kr"
-      #   crypto_key  = "vault-helm-unseal-key"
+      #   key_ring    = "vhsm-helm-unseal-kr"
+      #   crypto_key  = "vhsm-helm-unseal-key"
       #}
 
       # Example configuration for enabling Prometheus metrics.


### PR DESCRIPTION
This PR aims to replace all possible locations with `vhsm` and the like.

It adds me as the CODEOWNER for everything.

In addition to simple string replacements, all the tests are adjusted as well to use the `vhsm` cli.

The home-directory for `vhsm` is aligned with our current `Dockerfile`.

This also adds the `skip` to the chart-verifier for using verified images.

---

As for testing these changes:

I've ran all the tests and acceptance tests (fix for using a licence in a separate PR). This was done on the final state of refactoring - once all the PRs are done, I'll do a diff in case something went wrong during the rebasing.

For our own deployment and use case, this is the functional diff after performing `template`:

```diff
<             /usr/local/bin/docker-entrypoint.sh vault server -config=/tmp/storageconfig.hcl 
---
>             /usr/local/bin/docker-entrypoint.sh vhsm server -config=/tmp/storageconfig.hcl 
338c338
<               value: "/home/vault"
---
>               value: "/home/vhsm"
360c360
<               mountPath: /home/vault
---
>               mountPath: /home/vhsm
375c375
<               command: ["/bin/sh", "-ec", "vault status -tls-skip-verify"]
---
>               command: ["/bin/sh", "-ec", "vhsm status -tls-skip-verify"]
500c500
<           echo "Checking for sealed info in 'vault status' output"
---
>           echo "Checking for sealed info in 'vhsm status' output"
506c506
<             vault status -format yaml | grep -E '^sealed: (true|false)' && break
---
>             vhsm status -format yaml | grep -E '^sealed: (true|false)' && break
511c511
<             echo "timed out looking for sealed info in 'vault status' output"
---
>             echo "timed out looking for sealed info in 'vhsm status' output"
```