### PR TITLE
Move to helm-schema with no functional diff

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ KIND_K8S_VERSION ?= v1.33.2
 
 # Generate json schema for chart values. See test/README.md for more details.
 values-schema:
-	helm schema-gen values.yaml > values.schema.json
+	helm-schema -k title,description,default,required,additionalProperties
 
 test: test-image test-bats
 

--- a/test/README.md
+++ b/test/README.md
@@ -30,10 +30,7 @@ There is a make target for generating values.schema.json:
 
     make values-schema
 
-It relies on the helm [schema-gen plugin][schema-gen]. Note that some manual
-editing will be required, since several properties accept multiple data types.
-
-[schema-gen]: https://github.com/KnechtionsCoding/helm-schema-gen
+It relies on helm-schema.
 
 ## Helm test
 

--- a/values.schema.json
+++ b/values.schema.json
@@ -1,1309 +1,956 @@
 {
-    "$schema": "http://json-schema.org/schema#",
-    "type": "object",
-    "properties": {
-        "csi": {
-            "type": "object",
-            "properties": {
-                "agent": {
-                    "type": "object",
-                    "properties": {
-                        "enabled": {
-                            "type": "boolean"
-                        },
-                        "extraArgs": {
-                            "type": "array"
-                        },
-                        "image": {
-                            "type": "object",
-                            "properties": {
-                                "pullPolicy": {
-                                    "type": "string"
-                                },
-                                "repository": {
-                                    "type": "string"
-                                },
-                                "tag": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "logFormat": {
-                            "type": "string"
-                        },
-                        "logLevel": {
-                            "type": "string"
-                        },
-                        "resources": {
-                            "type": "object"
-                        }
-                    }
-                },
-                "daemonSet": {
-                    "type": "object",
-                    "properties": {
-                        "annotations": {
-                            "type": [
-                                "object",
-                                "string"
-                            ]
-                        },
-                        "extraLabels": {
-                            "type": "object"
-                        },
-                        "kubeletRootDir": {
-                            "type": "string"
-                        },
-                        "providersDir": {
-                            "type": "string"
-                        },
-                        "securityContext": {
-                            "type": "object",
-                            "properties": {
-                                "container": {
-                                    "type": [
-                                        "object",
-                                        "string"
-                                    ]
-                                },
-                                "pod": {
-                                    "type": [
-                                        "object",
-                                        "string"
-                                    ]
-                                }
-                            }
-                        },
-                        "updateStrategy": {
-                            "type": "object",
-                            "properties": {
-                                "maxUnavailable": {
-                                    "type": "string"
-                                },
-                                "type": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    }
-                },
-                "debug": {
-                    "type": "boolean"
-                },
-                "enabled": {
-                    "type": [
-                        "boolean",
-                        "string"
-                    ]
-                },
-                "extraArgs": {
-                    "type": "array"
-                },
-                "hmacSecretName": {
-                    "type": "string"
-                },
-                "image": {
-                    "type": "object",
-                    "properties": {
-                        "pullPolicy": {
-                            "type": "string"
-                        },
-                        "repository": {
-                            "type": "string"
-                        },
-                        "tag": {
-                            "type": "string"
-                        }
-                    }
-                },
-                "livenessProbe": {
-                    "type": "object",
-                    "properties": {
-                        "failureThreshold": {
-                            "type": "integer"
-                        },
-                        "initialDelaySeconds": {
-                            "type": "integer"
-                        },
-                        "periodSeconds": {
-                            "type": "integer"
-                        },
-                        "successThreshold": {
-                            "type": "integer"
-                        },
-                        "timeoutSeconds": {
-                            "type": "integer"
-                        }
-                    }
-                },
-                "pod": {
-                    "type": "object",
-                    "properties": {
-                        "affinity": {
-                            "type": [
-                              "null",
-                              "object",
-                              "string"
-                            ]
-                        },
-                        "annotations": {
-                            "type": [
-                                "object",
-                                "string"
-                            ]
-                        },
-                        "extraLabels": {
-                            "type": "object"
-                        },
-                        "nodeSelector": {
-                            "type": [
-                              "null",
-                              "object",
-                              "string"
-                            ]
-                        },
-                        "tolerations": {
-                            "type": [
-                                "null",
-                                "array",
-                                "string"
-                            ]
-                        }
-                    }
-                },
-                "priorityClassName": {
-                    "type": "string"
-                },
-                "readinessProbe": {
-                    "type": "object",
-                    "properties": {
-                        "failureThreshold": {
-                            "type": "integer"
-                        },
-                        "initialDelaySeconds": {
-                            "type": "integer"
-                        },
-                        "periodSeconds": {
-                            "type": "integer"
-                        },
-                        "successThreshold": {
-                            "type": "integer"
-                        },
-                        "timeoutSeconds": {
-                            "type": "integer"
-                        }
-                    }
-                },
-                "resources": {
-                    "type": "object"
-                },
-                "serviceAccount": {
-                    "type": "object",
-                    "properties": {
-                        "annotations": {
-                            "type": [
-                                "object",
-                                "string"
-                            ]
-                        },
-                        "extraLabels": {
-                            "type": "object"
-                        }
-                    }
-                },
-                "volumeMounts": {
-                    "type": [
-                        "null",
-                        "array"
-                    ]
-                },
-                "volumes": {
-                    "type": [
-                        "null",
-                        "array"
-                    ]
-                }
-            }
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "properties": {
+    "global": {
+      "properties": {
+        "enabled": {
+          "required": [],
+          "type": "boolean"
         },
-        "global": {
-            "type": "object",
-            "properties": {
-                "enabled": {
-                    "type": "boolean"
-                },
-                "externalVaultAddr": {
-                    "type": "string"
-                },
-                "imagePullSecrets": {
-                    "type": "array"
-                },
-                "namespace": {
-                    "type": "string"
-                },
-                "openshift": {
-                    "type": "boolean"
-                },
-                "psp": {
-                    "type": "object",
-                    "properties": {
-                        "annotations": {
-                            "type": [
-                                "object",
-                                "string"
-                            ]
-                        },
-                        "enable": {
-                            "type": "boolean"
-                        }
-                    }
-                },
-                "serverTelemetry": {
-                    "type": "object",
-                    "properties": {
-                        "prometheusOperator": {
-                            "type": "boolean"
-                        }
-                    }
-                },
-                "tlsDisable": {
-                    "type": "boolean"
-                }
-            }
+        "imagePullSecrets": {
+          "items": {
+            "required": []
+          },
+          "required": [],
+          "type": "array"
         },
-        "injector": {
-            "type": "object",
-            "properties": {
-                "affinity": {
-                    "type": [
-                        "object",
-                        "string"
-                    ]
-                },
-                "agentDefaults": {
-                    "type": "object",
-                    "properties": {
-                        "cpuLimit": {
-                            "type": "string"
-                        },
-                        "cpuRequest": {
-                            "type": "string"
-                        },
-                        "memLimit": {
-                            "type": "string"
-                        },
-                        "memRequest": {
-                            "type": "string"
-                        },
-                        "ephemeralLimit": {
-                            "type": "string"
-                        },
-                        "ephemeralRequest": {
-                            "type": "string"
-                        },
-                        "template": {
-                            "type": "string"
-                        },
-                        "templateConfig": {
-                            "type": "object",
-                            "properties": {
-                                "exitOnRetryFailure": {
-                                    "type": "boolean"
-                                },
-                                "staticSecretRenderInterval": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    }
-                },
-                "agentImage": {
-                    "type": "object",
-                    "properties": {
-                        "repository": {
-                            "type": "string"
-                        },
-                        "tag": {
-                            "type": "string"
-                        }
-                    }
-                },
-                "annotations": {
-                    "type": [
-                        "object",
-                        "string"
-                    ]
-                },
-                "authPath": {
-                    "type": "string"
-                },
-                "certs": {
-                    "type": "object",
-                    "properties": {
-                        "caBundle": {
-                            "type": "string"
-                        },
-                        "certName": {
-                            "type": "string"
-                        },
-                        "keyName": {
-                            "type": "string"
-                        },
-                        "secretName": {
-                            "type": [
-                                "null",
-                                "string"
-                            ]
-                        }
-                    }
-                },
-                "enabled": {
-                    "type": [
-                        "boolean",
-                        "string"
-                    ]
-                },
-                "externalVaultAddr": {
-                    "type": "string"
-                },
-                "extraEnvironmentVars": {
-                    "type": "object"
-                },
-                "extraLabels": {
-                    "type": "object"
-                },
-                "failurePolicy": {
-                    "type": "string"
-                },
-                "hostNetwork": {
-                    "type": "boolean"
-                },
-                "image": {
-                    "type": "object",
-                    "properties": {
-                        "pullPolicy": {
-                            "type": "string"
-                        },
-                        "repository": {
-                            "type": "string"
-                        },
-                        "tag": {
-                            "type": "string"
-                        }
-                    }
-                },
-                "leaderElector": {
-                    "type": "object",
-                    "properties": {
-                        "enabled": {
-                            "type": "boolean"
-                        }
-                    }
-                },
-                "livenessProbe": {
-                    "type": "object",
-                    "properties": {
-                        "failureThreshold": {
-                            "type": "integer"
-                        },
-                        "initialDelaySeconds": {
-                            "type": "integer"
-                        },
-                        "periodSeconds": {
-                            "type": "integer"
-                        },
-                        "successThreshold": {
-                            "type": "integer"
-                        },
-                        "timeoutSeconds": {
-                            "type": "integer"
-                        }
-                    }
-                },
-                "logFormat": {
-                    "type": "string"
-                },
-                "logLevel": {
-                    "type": "string"
-                },
-                "metrics": {
-                    "type": "object",
-                    "properties": {
-                        "enabled": {
-                            "type": "boolean"
-                        }
-                    }
-                },
-                "namespaceSelector": {
-                    "type": "object"
-                },
-                "nodeSelector": {
-                    "type": [
-                        "null",
-                        "object",
-                        "string"
-                    ]
-                },
-                "objectSelector": {
-                    "type": [
-                        "object",
-                        "string"
-                    ]
-                },
-                "podDisruptionBudget": {
-                    "type": "object"
-                },
-                "port": {
-                    "type": "integer"
-                },
-                "priorityClassName": {
-                    "type": "string"
-                },
-                "readinessProbe": {
-                    "type": "object",
-                    "properties": {
-                        "failureThreshold": {
-                            "type": "integer"
-                        },
-                        "initialDelaySeconds": {
-                            "type": "integer"
-                        },
-                        "periodSeconds": {
-                            "type": "integer"
-                        },
-                        "successThreshold": {
-                            "type": "integer"
-                        },
-                        "timeoutSeconds": {
-                            "type": "integer"
-                        }
-                    }
-                },
-                "replicas": {
-                    "type": "integer"
-                },
-                "resources": {
-                    "type": "object"
-                },
-                "revokeOnShutdown": {
-                    "type": "boolean"
-                },
-                "securityContext": {
-                    "type": "object",
-                    "properties": {
-                        "container": {
-                            "type": [
-                                "object",
-                                "string"
-                            ]
-                        },
-                        "pod": {
-                            "type": [
-                                "object",
-                                "string"
-                            ]
-                        }
-                    }
-                },
-                "service": {
-                    "type": "object",
-                    "properties": {
-                        "annotations": {
-                            "type": [
-                                "object",
-                                "string"
-                            ]
-                        }
-                    }
-                },
-                "serviceAccount": {
-                    "type": "object",
-                    "properties": {
-                        "annotations": {
-                            "type": [
-                                "object",
-                                "string"
-                            ]
-                        }
-                    }
-                },
-                "startupProbe": {
-                    "type": "object",
-                    "properties": {
-                        "failureThreshold": {
-                            "type": "integer"
-                        },
-                        "initialDelaySeconds": {
-                            "type": "integer"
-                        },
-                        "periodSeconds": {
-                            "type": "integer"
-                        },
-                        "successThreshold": {
-                            "type": "integer"
-                        },
-                        "timeoutSeconds": {
-                            "type": "integer"
-                        }
-                    }
-                },
-                "strategy": {
-                    "type": [
-                        "object",
-                        "string"
-                    ]
-                },
-                "tolerations": {
-                    "type": [
-                        "null",
-                        "array",
-                        "string"
-                    ]
-                },
-                "topologySpreadConstraints": {
-                    "type": [
-                        "null",
-                        "array",
-                        "string"
-                    ]
-                },
-                "webhook": {
-                    "type": "object",
-                    "properties": {
-                        "annotations": {
-                            "type": [
-                                "object",
-                                "string"
-                            ]
-                        },
-                        "failurePolicy": {
-                            "type": "string"
-                        },
-                        "matchPolicy": {
-                            "type": "string"
-                        },
-                        "namespaceSelector": {
-                            "type": "object"
-                        },
-                        "objectSelector": {
-                            "type": [
-                                "object",
-                                "string"
-                            ]
-                        },
-                        "timeoutSeconds": {
-                            "type": "integer"
-                        }
-                    }
-                },
-                "webhookAnnotations": {
-                    "type": [
-                        "object",
-                        "string"
-                    ]
-                }
-            }
+        "namespace": {
+          "required": [],
+          "type": "string"
         },
-        "server": {
-            "type": "object",
-            "properties": {
-                "affinity": {
-                    "type": [
-                        "object",
-                        "string"
-                    ]
-                },
-                "annotations": {
-                    "type": [
-                        "object",
-                        "string"
-                    ]
-                },
-                "auditStorage": {
-                    "type": "object",
-                    "properties": {
-                        "accessMode": {
-                            "type": "string"
-                        },
-                        "annotations": {
-                            "type": [
-                                "object",
-                                "string"
-                            ]
-                        },
-                        "enabled": {
-                            "type": [
-                                "boolean",
-                                "string"
-                            ]
-                        },
-                        "labels": {
-                            "type": [
-                                "object",
-                                "string"
-                            ]
-                        },
-                        "mountPath": {
-                            "type": "string"
-                        },
-                        "size": {
-                            "type": "string"
-                        },
-                        "storageClass": {
-                            "type": [
-                                "null",
-                                "string"
-                            ]
-                        }
-                    }
-                },
-                "authDelegator": {
-                    "type": "object",
-                    "properties": {
-                        "enabled": {
-                            "type": "boolean"
-                        }
-                    }
-                },
-                "configAnnotation": {
-                    "type": "boolean"
-                },
-                "dataStorage": {
-                    "type": "object",
-                    "properties": {
-                        "accessMode": {
-                            "type": "string"
-                        },
-                        "annotations": {
-                            "type": [
-                                "object",
-                                "string"
-                            ]
-                        },
-                        "enabled": {
-                            "type": [
-                                "boolean",
-                                "string"
-                            ]
-                        },
-                        "labels": {
-                            "type": [
-                                "object",
-                                "string"
-                            ]
-                        },
-                        "mountPath": {
-                            "type": "string"
-                        },
-                        "size": {
-                            "type": "string"
-                        },
-                        "storageClass": {
-                            "type": [
-                                "null",
-                                "string"
-                            ]
-                        }
-                    }
-                },
-                "dev": {
-                    "type": "object",
-                    "properties": {
-                        "devRootToken": {
-                            "type": "string"
-                        },
-                        "enabled": {
-                            "type": "boolean"
-                        }
-                    }
-                },
-                "enabled": {
-                    "type": [
-                        "boolean",
-                        "string"
-                    ]
-                },
-                "enterpriseLicense": {
-                    "type": "object",
-                    "properties": {
-                        "secretKey": {
-                            "type": "string"
-                        },
-                        "secretName": {
-                            "type": "string"
-                        }
-                    }
-                },
-                "extraArgs": {
-                    "type": "string"
-                },
-                "extraContainers": {
-                    "type": [
-                        "null",
-                        "array"
-                    ]
-                },
-                "extraEnvironmentVars": {
-                    "type": "object"
-                },
-                "extraInitContainers": {
-                    "type": [
-                        "null",
-                        "array"
-                    ]
-                },
-                "extraLabels": {
-                    "type": "object"
-                },
-                "extraPorts": {
-                    "type": [
-                        "null",
-                        "array"
-                    ]
-                },
-                "extraSecretEnvironmentVars": {
-                    "type": "array"
-                },
-                "extraVolumes": {
-                    "type": "array"
-                },
-                "ha": {
-                    "type": "object",
-                    "properties": {
-                        "apiAddr": {
-                            "type": [
-                                "null",
-                                "string"
-                            ]
-                        },
-                        "clusterAddr": {
-                            "type": [
-                                "null",
-                                "string"
-                            ]
-                        },
-                        "config": {
-                            "type": [
-                                "string",
-                                "object"
-                            ]
-                        },
-                        "disruptionBudget": {
-                            "type": "object",
-                            "properties": {
-                                "enabled": {
-                                    "type": "boolean"
-                                },
-                                "maxUnavailable": {
-                                    "type": [
-                                        "null",
-                                        "integer"
-                                    ]
-                                }
-                            }
-                        },
-                        "enabled": {
-                            "type": "boolean"
-                        },
-                        "raft": {
-                            "type": "object",
-                            "properties": {
-                                "config": {
-                                    "type": [
-                                        "string",
-                                        "object"
-                                    ]
-                                },
-                                "enabled": {
-                                    "type": "boolean"
-                                },
-                                "setNodeId": {
-                                    "type": "boolean"
-                                }
-                            }
-                        },
-                        "replicas": {
-                            "type": "integer"
-                        }
-                    }
-                },
-                "hostAliases": {
-                    "type": "array"
-                },
-                "hostNetwork": {
-                    "type": "boolean"
-                },
-                "image": {
-                    "type": "object",
-                    "properties": {
-                        "pullPolicy": {
-                            "type": "string"
-                        },
-                        "repository": {
-                            "type": "string"
-                        },
-                        "tag": {
-                            "type": "string"
-                        }
-                    }
-                },
-                "ingress": {
-                    "type": "object",
-                    "properties": {
-                        "activeService": {
-                            "type": "boolean"
-                        },
-                        "annotations": {
-                            "type": [
-                                "object",
-                                "string"
-                            ]
-                        },
-                        "enabled": {
-                            "type": "boolean"
-                        },
-                        "extraPaths": {
-                            "type": "array"
-                        },
-                        "hosts": {
-                            "type": "array",
-                            "items": {
-                                "type": "object",
-                                "properties": {
-                                    "host": {
-                                        "type": "string"
-                                    },
-                                    "paths": {
-                                        "type": "array"
-                                    }
-                                }
-                            }
-                        },
-                        "ingressClassName": {
-                            "type": "string"
-                        },
-                        "labels": {
-                            "type": "object"
-                        },
-                        "pathType": {
-                            "type": "string"
-                        },
-                        "tls": {
-                            "type": "array"
-                        }
-                    }
-                },
-                "livenessProbe": {
-                    "type": "object",
-                    "properties": {
-                        "enabled": {
-                            "type": "boolean"
-                        },
-                        "execCommand": {
-                            "type": "array"
-                        },
-                        "failureThreshold": {
-                            "type": "integer"
-                        },
-                        "initialDelaySeconds": {
-                            "type": "integer"
-                        },
-                        "path": {
-                            "type": "string"
-                        },
-                        "periodSeconds": {
-                            "type": "integer"
-                        },
-                        "port": {
-                            "type": "integer"
-                        },
-                        "successThreshold": {
-                            "type": "integer"
-                        },
-                        "timeoutSeconds": {
-                            "type": "integer"
-                        }
-                    }
-                },
-                "logFormat": {
-                    "type": "string"
-                },
-                "logLevel": {
-                    "type": "string"
-                },
-                "networkPolicy": {
-                    "type": "object",
-                    "properties": {
-                        "egress": {
-                            "type": "array"
-                        },
-                        "enabled": {
-                            "type": "boolean"
-                        },
-                        "ingress": {
-                            "type": "array"
-                        }
-                    }
-                },
-                "nodeSelector": {
-                    "type": [
-                        "null",
-                        "object",
-                        "string"
-                    ]
-                },
-                "persistentVolumeClaimRetentionPolicy": {
-                    "type": "object",
-                    "properties": {
-                        "whenDeleted": {
-                            "type": "string"
-                        },
-                        "whenScaled": {
-                            "type": "string"
-                        }
-                    }
-                },
-                "postStart": {
-                    "type": "array"
-                },
-                "preStopSleepSeconds": {
-                    "type": "integer"
-                },
-                "priorityClassName": {
-                    "type": "string"
-                },
-                "readinessProbe": {
-                    "type": "object",
-                    "properties": {
-                        "enabled": {
-                            "type": "boolean"
-                        },
-                        "failureThreshold": {
-                            "type": "integer"
-                        },
-                        "initialDelaySeconds": {
-                            "type": "integer"
-                        },
-                        "periodSeconds": {
-                            "type": "integer"
-                        },
-                        "port": {
-                            "type": "integer"
-                        },
-                        "successThreshold": {
-                            "type": "integer"
-                        },
-                        "timeoutSeconds": {
-                            "type": "integer"
-                        }
-                    }
-                },
-                "resources": {
-                    "type": "object"
-                },
-                "route": {
-                    "type": "object",
-                    "properties": {
-                        "activeService": {
-                            "type": "boolean"
-                        },
-                        "annotations": {
-                            "type": [
-                                "object",
-                                "string"
-                            ]
-                        },
-                        "enabled": {
-                            "type": "boolean"
-                        },
-                        "host": {
-                            "type": "string"
-                        },
-                        "labels": {
-                            "type": "object"
-                        },
-                        "tls": {
-                            "type": "object"
-                        }
-                    }
-                },
-                "service": {
-                    "type": "object",
-                    "properties": {
-                        "active": {
-                            "type": "object",
-                            "properties": {
-                                "annotations": {
-                                    "type": [
-                                        "object",
-                                        "string"
-                                    ]
-                                },
-                                "enabled": {
-                                    "type": "boolean"
-                                }
-                            }
-                        },
-                        "activeNodePort": {
-                            "type": "integer"
-                        },
-                        "annotations": {
-                            "type": [
-                                "object",
-                                "string"
-                            ]
-                        },
-                        "enabled": {
-                            "type": "boolean"
-                        },
-                        "externalTrafficPolicy": {
-                            "type": "string"
-                        },
-                        "instanceSelector": {
-                            "type": "object",
-                            "properties": {
-                                "enabled": {
-                                    "type": "boolean"
-                                }
-                            }
-                        },
-                        "ipFamilies": {
-                            "type": "array"
-                        },
-                        "ipFamilyPolicy": {
-                            "type": "string"
-                        },
-                        "nodePort": {
-                            "type": "integer"
-                        },
-                        "port": {
-                            "type": "integer"
-                        },
-                        "publishNotReadyAddresses": {
-                            "type": "boolean"
-                        },
-                        "standby": {
-                            "type": "object",
-                            "properties": {
-                                "annotations": {
-                                    "type": [
-                                        "object",
-                                        "string"
-                                    ]
-                                },
-                                "enabled": {
-                                    "type": "boolean"
-                                }
-                            }
-                        },
-                        "standbyNodePort": {
-                            "type": "integer"
-                        },
-                        "targetPort": {
-                            "type": "integer"
-                        }
-                    }
-                },
-                "serviceAccount": {
-                    "type": "object",
-                    "properties": {
-                        "annotations": {
-                            "type": [
-                                "object",
-                                "string"
-                            ]
-                        },
-                        "create": {
-                            "type": "boolean"
-                        },
-                        "createSecret": {
-                            "type": "boolean"
-                        },
-                        "extraLabels": {
-                            "type": "object"
-                        },
-                        "name": {
-                            "type": "string"
-                        },
-                        "serviceDiscovery": {
-                            "type": "object",
-                            "properties": {
-                                "enabled": {
-                                    "type": "boolean"
-                                }
-                            }
-                        }
-                    }
-                },
-                "shareProcessNamespace": {
-                    "type": "boolean"
-                },
-                "standalone": {
-                    "type": "object",
-                    "properties": {
-                        "config": {
-                            "type": [
-                                "string",
-                                "object"
-                            ]
-                        },
-                        "enabled": {
-                            "type": [
-                                "string",
-                                "boolean"
-                            ]
-                        }
-                    }
-                },
-                "statefulSet": {
-                    "type": "object",
-                    "properties": {
-                        "annotations": {
-                            "type": [
-                                "object",
-                                "string"
-                            ]
-                        },
-                        "securityContext": {
-                            "type": "object",
-                            "properties": {
-                                "container": {
-                                    "type": [
-                                        "object",
-                                        "string"
-                                    ]
-                                },
-                                "pod": {
-                                    "type": [
-                                        "object",
-                                        "string"
-                                    ]
-                                }
-                            }
-                        }
-                    }
-                },
-                "terminationGracePeriodSeconds": {
-                    "type": "integer"
-                },
-                "tolerations": {
-                    "type": [
-                        "null",
-                        "array",
-                        "string"
-                    ]
-                },
-                "topologySpreadConstraints": {
-                    "type": [
-                        "null",
-                        "array",
-                        "string"
-                    ]
-                },
-                "updateStrategyType": {
-                    "type": "string"
-                },
-                "volumeMounts": {
-                    "type": [
-                        "null",
-                        "array"
-                    ]
-                },
-                "volumes": {
-                    "type": [
-                        "null",
-                        "array"
-                    ]
-                }
+        "openshift": {
+          "required": [],
+          "type": "boolean"
+        },
+        "psp": {
+          "properties": {
+            "annotations": {
+              "required": [],
+              "type": [
+                "object",
+                "string"
+              ]
+            },
+            "enable": {
+              "required": [],
+              "type": "boolean"
             }
+          },
+          "required": [],
+          "type": "object"
         },
         "serverTelemetry": {
-            "type": "object",
-            "properties": {
-                "prometheusRules": {
-                    "type": "object",
-                    "properties": {
-                        "enabled": {
-                            "type": "boolean"
-                        },
-                        "rules": {
-                            "type": "array"
-                        },
-                        "selectors": {
-                            "type": "object"
-                        }
-                    }
-                },
-                "serviceMonitor": {
-                    "type": "object",
-                    "properties": {
-                        "authorization": {
-                            "type": "object"
-                        },
-                        "enabled": {
-                            "type": "boolean"
-                        },
-                        "interval": {
-                            "type": "string"
-                        },
-                        "scrapeTimeout": {
-                            "type": "string"
-                        },
-                        "selectors": {
-                            "type": "object"
-                        },
-                        "tlsConfig": {
-                            "type": "object"
-                        }
-                    }
-                }
+          "properties": {
+            "prometheusOperator": {
+              "required": [],
+              "type": "boolean"
             }
+          },
+          "required": [],
+          "type": "object"
         },
-        "ui": {
-            "type": "object",
-            "properties": {
-                "activeVaultPodOnly": {
-                    "type": "boolean"
+        "tlsDisable": {
+          "required": [],
+          "type": "boolean"
+        }
+      },
+      "required": [],
+      "type": "object"
+    },
+    "server": {
+      "properties": {
+        "affinity": {
+          "required": [],
+          "type": [
+            "object",
+            "string"
+          ]
+        },
+        "annotations": {
+          "required": [],
+          "type": [
+            "object",
+            "string"
+          ]
+        },
+        "auditStorage": {
+          "properties": {
+            "accessMode": {
+              "required": [],
+              "type": "string"
+            },
+            "annotations": {
+              "required": [],
+              "type": [
+                "object",
+                "string"
+              ]
+            },
+            "enabled": {
+              "required": [],
+              "type": [
+                "boolean",
+                "string"
+              ]
+            },
+            "labels": {
+              "required": [],
+              "type": [
+                "object",
+                "string"
+              ]
+            },
+            "mountPath": {
+              "required": [],
+              "type": "string"
+            },
+            "size": {
+              "required": [],
+              "type": "string"
+            },
+            "storageClass": {
+              "required": [],
+              "type": [
+                "null",
+                "string"
+              ]
+            }
+          },
+          "required": [],
+          "type": "object"
+        },
+        "authDelegator": {
+          "properties": {
+            "enabled": {
+              "required": [],
+              "type": "boolean"
+            }
+          },
+          "required": [],
+          "type": "object"
+        },
+        "configAnnotation": {
+          "required": [],
+          "type": "boolean"
+        },
+        "dataStorage": {
+          "properties": {
+            "accessMode": {
+              "required": [],
+              "type": "string"
+            },
+            "annotations": {
+              "required": [],
+              "type": [
+                "object",
+                "string"
+              ]
+            },
+            "enabled": {
+              "required": [],
+              "type": [
+                "boolean",
+                "string"
+              ]
+            },
+            "labels": {
+              "required": [],
+              "type": [
+                "object",
+                "string"
+              ]
+            },
+            "mountPath": {
+              "required": [],
+              "type": "string"
+            },
+            "size": {
+              "required": [],
+              "type": "string"
+            },
+            "storageClass": {
+              "required": [],
+              "type": [
+                "null",
+                "string"
+              ]
+            }
+          },
+          "required": [],
+          "type": "object"
+        },
+        "dev": {
+          "properties": {
+            "devRootToken": {
+              "required": [],
+              "type": "string"
+            },
+            "enabled": {
+              "required": [],
+              "type": "boolean"
+            }
+          },
+          "required": [],
+          "type": "object"
+        },
+        "enabled": {
+          "required": [],
+          "type": [
+            "boolean",
+            "string"
+          ]
+        },
+        "extraArgs": {
+          "required": [],
+          "type": "string"
+        },
+        "extraContainers": {
+          "required": [],
+          "type": [
+            "null",
+            "array"
+          ]
+        },
+        "extraEnvironmentVars": {
+          "required": [],
+          "type": "object"
+        },
+        "extraInitContainers": {
+          "required": [],
+          "type": [
+            "null",
+            "array"
+          ]
+        },
+        "extraLabels": {
+          "required": [],
+          "type": "object"
+        },
+        "extraPorts": {
+          "required": [],
+          "type": [
+            "null",
+            "array"
+          ]
+        },
+        "extraSecretEnvironmentVars": {
+          "items": {
+            "required": []
+          },
+          "required": [],
+          "type": "array"
+        },
+        "extraVolumes": {
+          "items": {
+            "required": []
+          },
+          "required": [],
+          "type": "array"
+        },
+        "ha": {
+          "properties": {
+            "apiAddr": {
+              "required": [],
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "clusterAddr": {
+              "required": [],
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "config": {
+              "required": [],
+              "type": [
+                "string",
+                "object"
+              ]
+            },
+            "disruptionBudget": {
+              "properties": {
+                "enabled": {
+                  "required": [],
+                  "type": "boolean"
                 },
-                "annotations": {
-                    "type": [
-                        "object",
-                        "string"
-                    ]
+                "maxUnavailable": {
+                  "required": [],
+                  "type": [
+                    "null",
+                    "integer"
+                  ]
+                }
+              },
+              "required": [],
+              "type": "object"
+            },
+            "enabled": {
+              "required": [],
+              "type": "boolean"
+            },
+            "raft": {
+              "properties": {
+                "config": {
+                  "required": [],
+                  "type": [
+                    "string",
+                    "object"
+                  ]
                 },
                 "enabled": {
-                    "type": [
-                        "boolean",
-                        "string"
-                    ]
+                  "required": [],
+                  "type": "boolean"
                 },
-                "externalPort": {
-                    "type": "integer"
-                },
-                "externalTrafficPolicy": {
-                    "type": "string"
-                },
-                "publishNotReadyAddresses": {
-                    "type": "boolean"
-                },
-                "serviceIPFamilies": {
-                    "type": "array"
-                },
-                "serviceIPFamilyPolicy": {
-                    "type": "string"
-                },
-                "serviceNodePort": {
-                    "type": [
-                        "null",
-                        "integer"
-                    ]
-                },
-                "serviceType": {
-                    "type": "string"
-                },
-                "targetPort": {
-                    "type": "integer"
+                "setNodeId": {
+                  "required": [],
+                  "type": "boolean"
                 }
+              },
+              "required": [],
+              "type": "object"
+            },
+            "replicas": {
+              "required": [],
+              "type": "integer"
             }
+          },
+          "required": [],
+          "type": "object"
+        },
+        "hostAliases": {
+          "items": {
+            "required": []
+          },
+          "required": [],
+          "type": "array"
+        },
+        "hostNetwork": {
+          "required": [],
+          "type": "boolean"
+        },
+        "image": {
+          "properties": {
+            "pullPolicy": {
+              "required": [],
+              "type": "string"
+            },
+            "repository": {
+              "required": [],
+              "type": "string"
+            },
+            "tag": {
+              "required": [],
+              "type": "string"
+            }
+          },
+          "required": [],
+          "type": "object"
+        },
+        "ingress": {
+          "properties": {
+            "activeService": {
+              "required": [],
+              "type": "boolean"
+            },
+            "annotations": {
+              "required": [],
+              "type": [
+                "object",
+                "string"
+              ]
+            },
+            "enabled": {
+              "required": [],
+              "type": "boolean"
+            },
+            "extraPaths": {
+              "items": {
+                "required": []
+              },
+              "required": [],
+              "type": "array"
+            },
+            "hosts": {
+              "items": {
+                "properties": {
+                  "host": {
+                    "required": [],
+                    "type": "string"
+                  },
+                  "paths": {
+                    "required": [],
+                    "type": "array"
+                  }
+                },
+                "required": [],
+                "type": "object"
+              },
+              "required": [],
+              "type": "array"
+            },
+            "ingressClassName": {
+              "required": [],
+              "type": "string"
+            },
+            "labels": {
+              "required": [],
+              "type": "object"
+            },
+            "pathType": {
+              "required": [],
+              "type": "string"
+            },
+            "tls": {
+              "items": {
+                "required": []
+              },
+              "required": [],
+              "type": "array"
+            }
+          },
+          "required": [],
+          "type": "object"
+        },
+        "livenessProbe": {
+          "properties": {
+            "enabled": {
+              "required": [],
+              "type": "boolean"
+            },
+            "execCommand": {
+              "items": {
+                "required": []
+              },
+              "required": [],
+              "type": "array"
+            },
+            "failureThreshold": {
+              "required": [],
+              "type": "integer"
+            },
+            "initialDelaySeconds": {
+              "required": [],
+              "type": "integer"
+            },
+            "path": {
+              "required": [],
+              "type": "string"
+            },
+            "periodSeconds": {
+              "required": [],
+              "type": "integer"
+            },
+            "port": {
+              "required": [],
+              "type": "integer"
+            },
+            "successThreshold": {
+              "required": [],
+              "type": "integer"
+            },
+            "timeoutSeconds": {
+              "required": [],
+              "type": "integer"
+            }
+          },
+          "required": [],
+          "type": "object"
+        },
+        "logFormat": {
+          "required": [],
+          "type": "string"
+        },
+        "logLevel": {
+          "required": [],
+          "type": "string"
+        },
+        "networkPolicy": {
+          "properties": {
+            "egress": {
+              "items": {
+                "required": []
+              },
+              "required": [],
+              "type": "array"
+            },
+            "enabled": {
+              "required": [],
+              "type": "boolean"
+            },
+            "ingress": {
+              "items": {
+                "required": []
+              },
+              "required": [],
+              "type": "array"
+            }
+          },
+          "required": [],
+          "type": "object"
+        },
+        "nodeSelector": {
+          "required": [],
+          "type": [
+            "null",
+            "object",
+            "string"
+          ]
+        },
+        "persistentVolumeClaimRetentionPolicy": {
+          "properties": {
+            "whenDeleted": {
+              "required": [],
+              "type": "string"
+            },
+            "whenScaled": {
+              "required": [],
+              "type": "string"
+            }
+          },
+          "required": [],
+          "type": "object"
+        },
+        "postStart": {
+          "items": {
+            "required": []
+          },
+          "required": [],
+          "type": "array"
+        },
+        "preStopSleepSeconds": {
+          "required": [],
+          "type": "integer"
+        },
+        "priorityClassName": {
+          "required": [],
+          "type": "string"
+        },
+        "readinessProbe": {
+          "properties": {
+            "enabled": {
+              "required": [],
+              "type": "boolean"
+            },
+            "failureThreshold": {
+              "required": [],
+              "type": "integer"
+            },
+            "initialDelaySeconds": {
+              "required": [],
+              "type": "integer"
+            },
+            "periodSeconds": {
+              "required": [],
+              "type": "integer"
+            },
+            "port": {
+              "required": [],
+              "type": "integer"
+            },
+            "successThreshold": {
+              "required": [],
+              "type": "integer"
+            },
+            "timeoutSeconds": {
+              "required": [],
+              "type": "integer"
+            }
+          },
+          "required": [],
+          "type": "object"
+        },
+        "resources": {
+          "required": [],
+          "type": "object"
+        },
+        "route": {
+          "properties": {
+            "activeService": {
+              "required": [],
+              "type": "boolean"
+            },
+            "annotations": {
+              "required": [],
+              "type": [
+                "object",
+                "string"
+              ]
+            },
+            "enabled": {
+              "required": [],
+              "type": "boolean"
+            },
+            "host": {
+              "required": [],
+              "type": "string"
+            },
+            "labels": {
+              "required": [],
+              "type": "object"
+            },
+            "tls": {
+              "required": [],
+              "type": "object"
+            }
+          },
+          "required": [],
+          "type": "object"
+        },
+        "service": {
+          "properties": {
+            "active": {
+              "properties": {
+                "annotations": {
+                  "required": [],
+                  "type": [
+                    "object",
+                    "string"
+                  ]
+                },
+                "enabled": {
+                  "required": [],
+                  "type": "boolean"
+                }
+              },
+              "required": [],
+              "type": "object"
+            },
+            "annotations": {
+              "required": [],
+              "type": [
+                "object",
+                "string"
+              ]
+            },
+            "enabled": {
+              "required": [],
+              "type": "boolean"
+            },
+            "externalTrafficPolicy": {
+              "required": [],
+              "type": "string"
+            },
+            "instanceSelector": {
+              "properties": {
+                "enabled": {
+                  "required": [],
+                  "type": "boolean"
+                }
+              },
+              "required": [],
+              "type": "object"
+            },
+            "ipFamilies": {
+              "items": {
+                "required": []
+              },
+              "required": [],
+              "type": "array"
+            },
+            "ipFamilyPolicy": {
+              "required": [],
+              "type": "string"
+            },
+            "port": {
+              "required": [],
+              "type": "integer"
+            },
+            "publishNotReadyAddresses": {
+              "required": [],
+              "type": "boolean"
+            },
+            "standby": {
+              "properties": {
+                "annotations": {
+                  "required": [],
+                  "type": [
+                    "object",
+                    "string"
+                  ]
+                },
+                "enabled": {
+                  "required": [],
+                  "type": "boolean"
+                }
+              },
+              "required": [],
+              "type": "object"
+            },
+            "targetPort": {
+              "required": [],
+              "type": "integer"
+            }
+          },
+          "required": [],
+          "type": "object"
+        },
+        "serviceAccount": {
+          "properties": {
+            "annotations": {
+              "required": [],
+              "type": [
+                "object",
+                "string"
+              ]
+            },
+            "create": {
+              "required": [],
+              "type": "boolean"
+            },
+            "createSecret": {
+              "required": [],
+              "type": "boolean"
+            },
+            "extraLabels": {
+              "required": [],
+              "type": "object"
+            },
+            "name": {
+              "required": [],
+              "type": "string"
+            },
+            "serviceDiscovery": {
+              "properties": {
+                "enabled": {
+                  "required": [],
+                  "type": "boolean"
+                }
+              },
+              "required": [],
+              "type": "object"
+            }
+          },
+          "required": [],
+          "type": "object"
+        },
+        "shareProcessNamespace": {
+          "required": [],
+          "type": "boolean"
+        },
+        "standalone": {
+          "properties": {
+            "config": {
+              "required": [],
+              "type": [
+                "string",
+                "object"
+              ]
+            },
+            "enabled": {
+              "required": [],
+              "type": [
+                "string",
+                "boolean"
+              ]
+            }
+          },
+          "required": [],
+          "type": "object"
+        },
+        "statefulSet": {
+          "properties": {
+            "annotations": {
+              "required": [],
+              "type": [
+                "object",
+                "string"
+              ]
+            },
+            "securityContext": {
+              "properties": {
+                "container": {
+                  "required": [],
+                  "type": [
+                    "object",
+                    "string"
+                  ]
+                },
+                "pod": {
+                  "required": [],
+                  "type": [
+                    "object",
+                    "string"
+                  ]
+                }
+              },
+              "required": [],
+              "type": "object"
+            }
+          },
+          "required": [],
+          "type": "object"
+        },
+        "terminationGracePeriodSeconds": {
+          "required": [],
+          "type": "integer"
+        },
+        "tolerations": {
+          "items": {
+            "required": []
+          },
+          "required": [],
+          "type": [
+            "null",
+            "array",
+            "string"
+          ]
+        },
+        "topologySpreadConstraints": {
+          "items": {
+            "required": []
+          },
+          "required": [],
+          "type": [
+            "null",
+            "array",
+            "string"
+          ]
+        },
+        "updateStrategyType": {
+          "required": [],
+          "type": "string"
+        },
+        "volumeMounts": {
+          "required": [],
+          "type": [
+            "null",
+            "array"
+          ]
+        },
+        "volumes": {
+          "required": [],
+          "type": [
+            "null",
+            "array"
+          ]
         }
+      },
+      "required": [],
+      "type": "object"
+    },
+    "serverTelemetry": {
+      "properties": {
+        "prometheusRules": {
+          "properties": {
+            "enabled": {
+              "required": [],
+              "type": "boolean"
+            },
+            "rules": {
+              "items": {
+                "required": []
+              },
+              "required": [],
+              "type": "array"
+            },
+            "selectors": {
+              "required": [],
+              "type": "object"
+            }
+          },
+          "required": [],
+          "type": "object"
+        },
+        "serviceMonitor": {
+          "properties": {
+            "authorization": {
+              "required": [],
+              "type": "object"
+            },
+            "enabled": {
+              "required": [],
+              "type": "boolean"
+            },
+            "interval": {
+              "required": [],
+              "type": "string"
+            },
+            "scrapeTimeout": {
+              "required": [],
+              "type": "string"
+            },
+            "selectors": {
+              "required": [],
+              "type": "object"
+            },
+            "tlsConfig": {
+              "required": [],
+              "type": "object"
+            }
+          },
+          "required": [],
+          "type": "object"
+        }
+      },
+      "required": [],
+      "type": "object"
+    },
+    "ui": {
+      "properties": {
+        "activeVaultPodOnly": {
+          "required": [],
+          "type": "boolean"
+        },
+        "annotations": {
+          "required": [],
+          "type": [
+            "object",
+            "string"
+          ]
+        },
+        "enabled": {
+          "required": [],
+          "type": [
+            "boolean",
+            "string"
+          ]
+        },
+        "externalPort": {
+          "required": [],
+          "type": "integer"
+        },
+        "externalTrafficPolicy": {
+          "required": [],
+          "type": "string"
+        },
+        "publishNotReadyAddresses": {
+          "required": [],
+          "type": "boolean"
+        },
+        "serviceIPFamilies": {
+          "items": {
+            "required": []
+          },
+          "required": [],
+          "type": "array"
+        },
+        "serviceIPFamilyPolicy": {
+          "required": [],
+          "type": "string"
+        },
+        "serviceNodePort": {
+          "required": [],
+          "type": [
+            "null",
+            "integer"
+          ]
+        },
+        "serviceType": {
+          "required": [],
+          "type": "string"
+        },
+        "targetPort": {
+          "required": [],
+          "type": "integer"
+        }
+      },
+      "required": [],
+      "type": "object"
     }
+  },
+  "required": [],
+  "type": "object"
 }

--- a/values.yaml
+++ b/values.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
-# Available parameters and their default values for the Vault chart.
+# Available parameters and their default values for the vHSM chart.
 
 global:
   # enabled is the master enabled switch. Setting this to true or false
@@ -19,9 +19,15 @@ global:
   tlsDisable: true
   # If deploying to OpenShift
   openshift: false
+  # @schema
+  # type: object
+  # @schema
   # Create PodSecurityPolicy for pods
   psp:
     enable: false
+    # @schema
+    # type: [object, string]
+    # @schema
     # Annotation for PodSecurityPolicy.
     # This is a multi-line templated string map, and can also be set as YAML.
     annotations: |
@@ -35,6 +41,9 @@ global:
     prometheusOperator: false
 
 server:
+  # @schema
+  # type: [boolean, string]
+  # @schema
   # If true, or "-" with global.enabled true, Vault server will be installed.
   # See vault.mode in _helpers.tpl for implementation details.
   enabled: "-"
@@ -70,7 +79,13 @@ server:
   # In order to expose the service, use the route section below
   ingress:
     enabled: false
+    # @schema
+    # type: object
+    # @schema
     labels: {}
+    # @schema
+    # type: [object, string]
+    # @schema
     # traffic: external
     annotations: {}
     # |
@@ -89,6 +104,16 @@ server:
     # When HA mode is enabled and K8s service registration is being used,
     # configure the ingress to point to the Vault active service.
     activeService: true
+    # @schema
+    # type: array
+    # items:
+    #   type: object
+    #   properties:
+    #     host:
+    #       type: string
+    #     paths:
+    #       type: array
+    # @schema
     hosts:
       - host: chart-example.local
         paths: []
@@ -117,9 +142,19 @@ server:
     # When HA mode is enabled and K8s service registration is being used,
     # configure the route to point to the Vault active service.
     activeService: true
+    # @schema
+    # type: object
+    # @schema
     labels: {}
+    # @schema
+    # type: [object, string]
+    # @schema
     annotations: {}
     host: chart-example.local
+    # @schema
+    # type: object
+    # properties: {}
+    # @schema
     # tls will be passed directly to the route's TLS config, which
     # can be used to configure other termination methods that terminate
     # TLS at the router
@@ -130,6 +165,9 @@ server:
   # method. See https://developer.hashicorp.com/vault/docs/auth/kubernetes
   authDelegator:
     enabled: true
+  # @schema
+  # type: [null, array]
+  # @schema
   # extraInitContainers is a list of init containers. Specified as a YAML list.
   # This is useful if you need to run a script to provision TLS certificates or
   # write out configuration files in a dynamic way.
@@ -149,6 +187,9 @@ server:
   #     - name: plugins
   #       mountPath: /usr/local/libexec/vhsm
 
+  # @schema
+  # type: [null, array]
+  # @schema
   # extraContainers is a list of sidecar containers. Specified as a YAML list.
   extraContainers: null
   # shareProcessNamespace enables process namespace sharing between Vault and the extraContainers
@@ -156,6 +197,9 @@ server:
   shareProcessNamespace: false
   # extraArgs is a string containing additional Vault server arguments.
   extraArgs: ""
+  # @schema
+  # type: [null, array]
+  # @schema
   # extraPorts is a list of extra ports. Specified as a YAML list.
   # This is useful if you need to add additional ports to the statefulset in dynamic way.
   extraPorts: null
@@ -222,6 +266,9 @@ server:
   # GOOGLE_PROJECT: myproject
   # GOOGLE_APPLICATION_CREDENTIALS: /vault/userconfig/myproject/myproject-creds.json
 
+  # @schema
+  # type: array
+  # @schema
   # extraSecretEnvironmentVars is a list of extra environment variables to set with the stateful set.
   # These variables take value from existing Secret objects.
   extraSecretEnvironmentVars: []
@@ -229,6 +276,9 @@ server:
   #   secretName: vault
   #   secretKey: AWS_SECRET_ACCESS_KEY
 
+  # @schema
+  # type: array
+  # @schema
   # Deprecated: please use 'volumes' instead.
   # extraVolumes is a list of extra volumes to mount. These will be exposed
   # to Vault in the path `/vault/userconfig/<name>/`. The value below is
@@ -238,6 +288,9 @@ server:
   #   name: my-secret
   #   path: null # default is `/vault/userconfig`
 
+  # @schema
+  # type: [null, array]
+  # @schema
   # volumes is a list of volumes made available to all containers. These are rendered
   # via toYaml rather than pre-processed like the extraVolumes value.
   # The purpose is to make it easy to share volumes between containers.
@@ -245,6 +298,9 @@ server:
   #   - name: plugins
   #     emptyDir: {}
 
+  # @schema
+  # type: [null, array]
+  # @schema
   # volumeMounts is a list of volumeMounts for the main server container. These are rendered
   # via toYaml rather than pre-processed like the extraVolumes value.
   # The purpose is to make it easy to share volumes between containers.
@@ -253,6 +309,9 @@ server:
   #     name: plugins
   #     readOnly: true
 
+  # @schema
+  # type: [object, string]
+  # @schema
   # Affinity Settings
   # Commenting out or setting as empty the affinity variable, will allow
   # deployment to single node services such as Minikube
@@ -266,15 +325,24 @@ server:
               app.kubernetes.io/instance: "{{ .Release.Name }}"
               component: server
           topologyKey: kubernetes.io/hostname
+  # @schema
+  # type: [null, array, string]
+  # @schema
   # Topology settings for server pods
   # ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
   # This should be either a multi-line string or YAML matching the topologySpreadConstraints array
   # in a PodSpec.
   topologySpreadConstraints: []
+  # @schema
+  # type: [null, array, string]
+  # @schema
   # Toleration Settings for server pods
   # This should be either a multi-line string or YAML matching the Toleration array
   # in a PodSpec.
   tolerations: []
+  # @schema
+  # type: [null, object, string]
+  # @schema
   # nodeSelector labels for server pod assignment, formatted as a multi-line string or YAML map.
   # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
   # Example:
@@ -292,6 +360,10 @@ server:
     #   ports:
     #   - protocol: TCP
     #     port: 443
+    # @schema
+    # type: array
+    # items: {}
+    # @schema
     ingress:
       - from:
           - namespaceSelector: {}
@@ -305,6 +377,9 @@ server:
   # Extra labels to attach to the server pods
   # This should be a YAML map of the labels to apply to the server pods
   extraLabels: {}
+  # @schema
+  # type: [object, string]
+  # @schema
   # Extra annotations to attach to the server pods
   # This can either be YAML or a YAML-formatted multi-line templated string map
   # of the annotations to apply to the server pods
@@ -322,6 +397,9 @@ server:
     # have labeled themselves as the cluster leader with `vault-active: "true"`.
     active:
       enabled: true
+      # @schema
+      # type: [object, string]
+      # @schema
       # Extra annotations for the service definition. This can either be YAML or a
       # YAML-formatted multi-line templated string map of the annotations to apply
       # to the active service.
@@ -330,6 +408,9 @@ server:
     # have labeled themselves as a cluster follower with `vault-active: "false"`.
     standby:
       enabled: true
+      # @schema
+      # type: [object, string]
+      # @schema
       # Extra annotations for the service definition. This can either be YAML or a
       # YAML-formatted multi-line templated string map of the annotations to apply
       # to the standby service.
@@ -382,6 +463,7 @@ server:
     # will be random if left blank.
     #activeNodePort: 30001
 
+    # Deprecation: unused value
     # When HA mode is enabled
     # If type is set to "NodePort", a specific nodePort value can be configured,
     # will be random if left blank.
@@ -389,8 +471,14 @@ server:
 
     # Port on which Vault server is listening
     port: 8200
+    # @schema
+    # type: integer
+    # @schema
     # Target port to which the service should be mapped to
     targetPort: 8200
+    # @schema
+    # type: [object, string]
+    # @schema
     # Extra annotations for the service definition. This can either be YAML or a
     # YAML-formatted multi-line templated string map of the annotations to apply
     # to the service.
@@ -399,20 +487,40 @@ server:
   # storage when using the file or raft backend storage engines.
   # See https://developer.hashicorp.com/vault/docs/configuration/storage to know more
   dataStorage:
+    # @schema
+    # type: [boolean, string]
+    # @schema
     enabled: true
     # Size of the PVC created
     size: 10Gi
     # Location where the PVC will be mounted.
     mountPath: "/vault/data"
+    # @schema
+    # type: [null, string]
+    # @schema
     # Name of the storage class to use.  If null it will use the
     # configured default Storage Class.
     storageClass: null
     # Access Mode of the storage device being used for the PVC
     accessMode: ReadWriteOnce
+    # @schema
+    # type: [object, string]
+    # @schema
     # Annotations to apply to the PVC
     annotations: {}
+    # @schema
+    # type: [object, string]
+    # @schema
     # Labels to apply to the PVC
     labels: {}
+  # @schema
+  # type: object
+  # properties:
+  #   whenDeleted:
+  #     type: string
+  #   whenScaled:
+  #     type: string
+  # @schema
   # Persistent Volume Claim (PVC) retention policy
   # ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#persistentvolumeclaim-retention
   # Example:
@@ -426,18 +534,30 @@ server:
   # /vault/audit
   # See https://developer.hashicorp.com/vault/docs/audit to know more
   auditStorage:
+    # @schema
+    # type: [boolean, string]
+    # @schema
     enabled: false
     # Size of the PVC created
     size: 10Gi
     # Location where the PVC will be mounted.
     mountPath: "/vault/audit"
+    # @schema
+    # type: [null, string]
+    # @schema
     # Name of the storage class to use.  If null it will use the
     # configured default Storage Class.
     storageClass: null
     # Access Mode of the storage device being used for the PVC
     accessMode: ReadWriteOnce
+    # @schema
+    # type: [object, string]
+    # @schema
     # Annotations to apply to the PVC
     annotations: {}
+    # @schema
+    # type: [object, string]
+    # @schema
     # Labels to apply to the PVC
     labels: {}
   # Run Vault in "dev" mode. This requires no further setup, no state management,
@@ -454,12 +574,18 @@ server:
   # the "file" backend.  This mode is not highly available and should not be scaled
   # past a single replica.
   standalone:
+    # @schema
+    # type: [string, boolean]
+    # @schema
     enabled: "-"
     # config is a raw string of default configuration when using a Stateful
     # deployment. Default is to use a PersistentVolumeClaim mounted at /vault/data
     # and store data there. This is only used when using a Replica count of 1, and
     # using a stateful set. This should be HCL.
 
+    # @schema
+    # type: [string, object]
+    # @schema
     # Note: Configuration files are stored in ConfigMaps so sensitive data
     # such as passwords should be either mounted through extraSecretEnvironmentVars
     # or through a Kube secret.  For more information see:
@@ -502,11 +628,21 @@ server:
   # different HA backend.
   ha:
     enabled: false
+    # @schema
+    # type: integer
+    # required: false
+    # @schema
     replicas: 3
+    # @schema
+    # type: [null, string]
+    # @schema
     # Set the api_addr configuration for Vault HA
     # See https://developer.hashicorp.com/vault/docs/configuration#api_addr
     # If set to null, this will be set to the Pod IP Address
     apiAddr: null
+    # @schema
+    # type: [null, string]
+    # @schema
     # Set the cluster_addr confuguration for Vault HA
     # See https://developer.hashicorp.com/vault/docs/configuration#cluster_addr
     # If set to null, this will be set to https://$(HOSTNAME).{{ template "vault.fullname" . }}-internal:8201
@@ -520,6 +656,9 @@ server:
       enabled: false
       # Set the Node Raft ID to the name of the pod
       setNodeId: false
+      # @schema
+      # type: [string, object]
+      # @schema
       # Note: Configuration files are stored in ConfigMaps so sensitive data
       # such as passwords should be either mounted through extraSecretEnvironmentVars
       # or through a Kube secret.  For more information see:
@@ -546,6 +685,9 @@ server:
     # deployment. Default is to use a Consul for its HA storage backend.
     # This should be HCL.
 
+    # @schema
+    # type: [string, object]
+    # @schema
     # Note: Configuration files are stored in ConfigMaps so sensitive data
     # such as passwords should be either mounted through extraSecretEnvironmentVars
     # or through a Kube secret.  For more information see:
@@ -586,6 +728,9 @@ server:
     # that are down simultaneously from voluntary disruptions
     disruptionBudget:
       enabled: true
+      # @schema
+      # type: [null, integer]
+      # @schema
       # maxUnavailable will default to (n/2)-1 where n is the number of
       # replicas. If you'd like a custom value, you can specify an override here.
       maxUnavailable: null
@@ -604,6 +749,9 @@ server:
     # For more details, see https://kubernetes.io/docs/concepts/configuration/secret/#service-account-token-secrets
     # serviceAccount.create must be equal to 'true' in order to use this feature.
     createSecret: false
+    # @schema
+    # type: [object, string]
+    # @schema
     # Extra annotations for the serviceAccount definition. This can either be
     # YAML or a YAML-formatted multi-line templated string map of the
     # annotations to apply to the serviceAccount.
@@ -618,6 +766,9 @@ server:
       enabled: true
   # Settings for the statefulSet used to run Vault.
   statefulSet:
+    # @schema
+    # type: [object, string]
+    # @schema
     # Extra annotations for the statefulSet. This can either be YAML or a
     # YAML-formatted multi-line templated string map of the annotations to apply
     # to the statefulSet.
@@ -636,12 +787,21 @@ server:
     # pod: {}
     # container: {}
     securityContext:
+      # @schema
+      # type: [object, string]
+      # @schema
       pod: {}
+      # @schema
+      # type: [object, string]
+      # @schema
       container: {}
   # Should the server pods run on the host network
   hostNetwork: false
-# Vault UI
+# vHSM UI
 ui:
+  # @schema
+  # type: [boolean, string]
+  # @schema
   # True if you want to create a Service entry for the Vault UI.
   #
   # serviceType can be used to control the type of service created. For
@@ -652,6 +812,9 @@ ui:
   # The service should only contain selectors for active Vault pod
   activeVaultPodOnly: false
   serviceType: "ClusterIP"
+  # @schema
+  # type: [null, integer]
+  # @schema
   serviceNodePort: null
   externalPort: 8200
   targetPort: 8200
@@ -679,6 +842,9 @@ ui:
 
   # loadBalancerIP:
 
+  # @schema
+  # type: [object, string]
+  # @schema
   # Extra annotations to attach to the ui service
   # This can either be YAML or a YAML-formatted multi-line templated string map
   # of the annotations to apply to the ui service
@@ -723,6 +889,8 @@ serverTelemetry:
 
     # Enable deployment of the Vault Server ServiceMonitor CustomResource.
     enabled: false
+    tlsConfig: {}
+    authorization: {}
     # Selector labels to add to the ServiceMonitor.
     # When empty, defaults to:
     #  release: prometheus


### PR DESCRIPTION
After all the refactoring, we have to recreate the `values.schema.json`.

This was previously done using the `helm schema` plugin with manual editing required as per the README.

This PR aims to replace it with [helm-schema](https://github.com/dadav/helm-schema).

Additional annotations in the `values.yaml` are added to preserve as much equality with the original version as we can.

This is the diff using `jd`:
```diff
@ ["$schema"]
- "http://json-schema.org/schema#"
+ "http://json-schema.org/draft-07/schema#"
@ ["properties","csi"]
- {"properties":{<SNIP>},"type":"object"}
--
@ ["properties","global","properties","externalVaultAddr"]
- {"type":"string"}
--
@ ["properties","injector"]
- {"properties":{<SNIP>},"type":"object"}
--
@ ["properties","server","properties","enterpriseLicense"]
- {"properties":{"secretKey":{"type":"string"},"secretName":{"type":"string"}},"type":"object"}
--
@ ["properties","server","properties","service","properties","activeNodePort"]
- {"type":"integer"}
--
@ ["properties","server","properties","service","properties","nodePort"]
- {"type":"integer"}
--
@ ["properties","server","properties","service","properties","standbyNodePort"]
- {"type":"integer"}

```
Command: `jd a.json b.json | grep -Ev '^\+ (\[\]|{"required":\[\]})$' | grep -E '^(\+|-)' -B 1`
The filtering removes newly added `required` fields that are set to empty arrays.

By this diff, I only removed `csi`, `injector`, `externalVaultAddr` and `enterpriseLicense` without changing type specifications.

Regarding the three port fields on `server.service`, these are just additional type specifications we don't require and that can't be set easily as to my current understanding of `helm-schema` annotations.

No more hand-crafting the schema.