### PR TITLE
Update README.md with new version number for chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ To install the latest version of this chart, retrieve it from Enclaive Harbor:
 
 ```sh
 helm template oci://harbor.enclaive.cloud/vhsm/vhsm \
-  --version 0.28.6 \
+  --version 0.29.0 \
   --set server.extraEnvironmentVars.ENCLAIVE_LICENCE="$licence"
 ```
 


### PR DESCRIPTION
This updates to the current chart version `v0.29.0` to prepare the final release.