### PR TITLE
Add first-class licence field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+Features:
+
+* server: Add `server.licence` field as a first-class way to set the `ENCLAIVE_LICENCE` env var, supporting either an inline value or a reference to an existing Kubernetes Secret. Closes [GH-23](https://github.com/enclaive/vhsm-helm/issues/23).
+
 ## 0.28.1 (Januar 15, 2025)
 
 Changes:

--- a/README.md
+++ b/README.md
@@ -28,7 +28,18 @@ To install the latest version of this chart, retrieve it from Enclaive Harbor:
 ```sh
 helm template oci://harbor.enclaive.cloud/vhsm/vhsm \
   --version 0.29.2 \
-  --set server.extraEnvironmentVars.ENCLAIVE_LICENCE="$licence"
+  --set server.licence.value="$licence"
+```
+
+For production deployments, reference an existing Kubernetes Secret instead
+of passing the licence on the command line:
+
+```sh
+kubectl create secret generic vhsm-licence --from-literal=licence="$licence"
+
+helm template oci://harbor.enclaive.cloud/vhsm/vhsm \
+  --version 0.29.2 \
+  --set server.licence.secretName=vhsm-licence
 ```
 
 Please see the many options supported in the `values.yaml` file. 

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -643,6 +643,29 @@ Inject extra environment populated by secrets, if populated
 {{- end -}}
 {{- end -}}
 
+{{/*
+Inject the ENCLAIVE_LICENCE env var from server.licence.
+Set server.licence.value for an inline value or server.licence.secretName
+plus server.licence.secretKey for a Secret reference. Setting both is an
+error. Setting neither renders nothing, leaving ENCLAIVE_LICENCE to be
+provided through extraEnvironmentVars or extraSecretEnvironmentVars.
+*/}}
+{{- define "vault.licenceEnv" -}}
+{{- $l := .Values.server.licence -}}
+{{- if and $l.value $l.secretName -}}
+{{- fail "server.licence.value and server.licence.secretName are mutually exclusive" -}}
+{{- else if $l.value -}}
+- name: ENCLAIVE_LICENCE
+  value: {{ $l.value | quote }}
+{{- else if $l.secretName -}}
+- name: ENCLAIVE_LICENCE
+  valueFrom:
+    secretKeyRef:
+      name: {{ $l.secretName }}
+      key: {{ $l.secretKey | default "licence" }}
+{{- end -}}
+{{- end -}}
+
 {{/* Scheme for health check and local endpoint */}}
 {{- define "vault.scheme" -}}
 {{- if .Values.global.tlsDisable -}}

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -138,6 +138,7 @@ spec:
               value: "{{ .Values.server.logFormat }}"
             {{- end }}
             {{ template "vault.envs" . }}
+            {{- include "vault.licenceEnv" . | nindent 12 }}
             {{- include "vault.extraEnvironmentVars" .Values.server | nindent 12 }}
             {{- include "vault.extraSecretEnvironmentVars" .Values.server | nindent 12 }}
           volumeMounts:

--- a/test/unit/server-dev-statefulset.bats
+++ b/test/unit/server-dev-statefulset.bats
@@ -339,6 +339,37 @@ load _helpers
 }
 
 #--------------------------------------------------------------------
+# licence
+
+@test "server/dev-StatefulSet: licence.value renders inline env var" {
+  cd `chart_dir`
+  local object=$(helm template \
+      --show-only templates/server-statefulset.yaml  \
+      --set 'server.dev.enabled=true' \
+      --set 'server.licence.value=dev-licence' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].env' | tee /dev/stderr)
+
+  local value=$(echo $object |
+      yq -r 'map(select(.name=="ENCLAIVE_LICENCE")) | .[] .value' | tee /dev/stderr)
+  [ "${value}" = "dev-licence" ]
+}
+
+@test "server/dev-StatefulSet: licence.secretName renders valueFrom.secretKeyRef" {
+  cd `chart_dir`
+  local object=$(helm template \
+      --show-only templates/server-statefulset.yaml  \
+      --set 'server.dev.enabled=true' \
+      --set 'server.licence.secretName=dev-licence-secret' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].env' | tee /dev/stderr)
+
+  local name=$(echo $object |
+      yq -r 'map(select(.name=="ENCLAIVE_LICENCE")) | .[] .valueFrom.secretKeyRef.name' | tee /dev/stderr)
+  [ "${name}" = "dev-licence-secret" ]
+}
+
+#--------------------------------------------------------------------
 # storage class
 
 @test "server/dev-StatefulSet: can't set storageClass" {

--- a/test/unit/server-ha-statefulset.bats
+++ b/test/unit/server-ha-statefulset.bats
@@ -396,6 +396,37 @@ load _helpers
 }
 
 #--------------------------------------------------------------------
+# licence
+
+@test "server/ha-StatefulSet: licence.value renders inline env var" {
+  cd `chart_dir`
+  local object=$(helm template \
+      --show-only templates/server-statefulset.yaml  \
+      --set 'server.ha.enabled=true' \
+      --set 'server.licence.value=ha-licence' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].env' | tee /dev/stderr)
+
+  local value=$(echo $object |
+      yq -r 'map(select(.name=="ENCLAIVE_LICENCE")) | .[] .value' | tee /dev/stderr)
+  [ "${value}" = "ha-licence" ]
+}
+
+@test "server/ha-StatefulSet: licence.secretName renders valueFrom.secretKeyRef" {
+  cd `chart_dir`
+  local object=$(helm template \
+      --show-only templates/server-statefulset.yaml  \
+      --set 'server.ha.enabled=true' \
+      --set 'server.licence.secretName=ha-licence-secret' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].env' | tee /dev/stderr)
+
+  local name=$(echo $object |
+      yq -r 'map(select(.name=="ENCLAIVE_LICENCE")) | .[] .valueFrom.secretKeyRef.name' | tee /dev/stderr)
+  [ "${name}" = "ha-licence-secret" ]
+}
+
+#--------------------------------------------------------------------
 # VAULT_API_ADDR renders
 
 @test "server/ha-StatefulSet: api addr renders to Pod IP by default" {

--- a/test/unit/server-statefulset.bats
+++ b/test/unit/server-statefulset.bats
@@ -643,6 +643,81 @@ load _helpers
 }
 
 #--------------------------------------------------------------------
+# licence
+
+@test "server/standalone-StatefulSet: licence not rendered by default" {
+  cd `chart_dir`
+  local object=$(helm template \
+      --show-only templates/server-statefulset.yaml  \
+      --set 'server.standalone.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].env' | tee /dev/stderr)
+
+  local count=$(echo $object |
+      yq -r 'map(select(.name=="ENCLAIVE_LICENCE")) | length' | tee /dev/stderr)
+  [ "${count}" = "0" ]
+}
+
+@test "server/standalone-StatefulSet: licence.value renders inline env var" {
+  cd `chart_dir`
+  local object=$(helm template \
+      --show-only templates/server-statefulset.yaml  \
+      --set 'server.standalone.enabled=true' \
+      --set 'server.licence.value=test-licence-123' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].env' | tee /dev/stderr)
+
+  local value=$(echo $object |
+      yq -r 'map(select(.name=="ENCLAIVE_LICENCE")) | .[] .value' | tee /dev/stderr)
+  [ "${value}" = "test-licence-123" ]
+}
+
+@test "server/standalone-StatefulSet: licence.secretName renders valueFrom.secretKeyRef" {
+  cd `chart_dir`
+  local object=$(helm template \
+      --show-only templates/server-statefulset.yaml  \
+      --set 'server.standalone.enabled=true' \
+      --set 'server.licence.secretName=my-licence-secret' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].env' | tee /dev/stderr)
+
+  local name=$(echo $object |
+      yq -r 'map(select(.name=="ENCLAIVE_LICENCE")) | .[] .valueFrom.secretKeyRef.name' | tee /dev/stderr)
+  [ "${name}" = "my-licence-secret" ]
+
+  local key=$(echo $object |
+      yq -r 'map(select(.name=="ENCLAIVE_LICENCE")) | .[] .valueFrom.secretKeyRef.key' | tee /dev/stderr)
+  [ "${key}" = "licence" ]
+}
+
+@test "server/standalone-StatefulSet: licence.secretKey overrides default key" {
+  cd `chart_dir`
+  local object=$(helm template \
+      --show-only templates/server-statefulset.yaml  \
+      --set 'server.standalone.enabled=true' \
+      --set 'server.licence.secretName=my-licence-secret' \
+      --set 'server.licence.secretKey=custom-key' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].env' | tee /dev/stderr)
+
+  local key=$(echo $object |
+      yq -r 'map(select(.name=="ENCLAIVE_LICENCE")) | .[] .valueFrom.secretKeyRef.key' | tee /dev/stderr)
+  [ "${key}" = "custom-key" ]
+}
+
+@test "server/standalone-StatefulSet: licence.value and licence.secretName together fail" {
+  cd `chart_dir`
+  run helm template \
+      --show-only templates/server-statefulset.yaml  \
+      --set 'server.standalone.enabled=true' \
+      --set 'server.licence.value=foo' \
+      --set 'server.licence.secretName=bar' \
+      .
+  [ "$status" -ne 0 ]
+  [[ "$output" =~ "mutually exclusive" ]]
+}
+
+#--------------------------------------------------------------------
 # storage class
 
 @test "server/standalone-StatefulSet: storageClass on claim by default" {

--- a/values.schema.json
+++ b/values.schema.json
@@ -414,6 +414,24 @@
           "required": [],
           "type": "object"
         },
+        "licence": {
+          "properties": {
+            "value": {
+              "required": [],
+              "type": "string"
+            },
+            "secretName": {
+              "required": [],
+              "type": "string"
+            },
+            "secretKey": {
+              "required": [],
+              "type": "string"
+            }
+          },
+          "required": [],
+          "type": "object"
+        },
         "livenessProbe": {
           "properties": {
             "enabled": {

--- a/values.yaml
+++ b/values.yaml
@@ -277,6 +277,24 @@ server:
   #   secretKey: AWS_SECRET_ACCESS_KEY
 
   # @schema
+  # type: object
+  # @schema
+  # Configures the ENCLAIVE_LICENCE environment variable that vHSM requires at
+  # startup. Provide either an inline value (not recommended for production) or
+  # a reference to an existing Kubernetes Secret. If both are set the chart
+  # fails to render. If neither is set, no licence env var is injected and the
+  # user may still configure ENCLAIVE_LICENCE through extraEnvironmentVars or
+  # extraSecretEnvironmentVars for backward compatibility.
+  licence:
+    # Inline licence string. Renders ENCLAIVE_LICENCE as a plain env var.
+    value: ""
+    # Reference an existing Kubernetes Secret containing the licence.
+    # Renders ENCLAIVE_LICENCE as a valueFrom.secretKeyRef.
+    secretName: ""
+    # Key within the referenced Secret.
+    secretKey: "licence"
+
+  # @schema
   # type: array
   # @schema
   # Deprecated: please use 'volumes' instead.


### PR DESCRIPTION
## Summary

Closes #23. Adds `server.licence` as a first-class field for the `ENCLAIVE_LICENCE` environment variable, replacing the `--set server.extraEnvironmentVars.ENCLAIVE_LICENCE="$licence"` workaround in the README.

## Design

```yaml
server:
  licence:
    value: ""           # inline (dev/test convenience)
    secretName: ""      # OR reference an existing Secret
    secretKey: licence  # key inside the Secret (default "licence")
```

- `value` set → renders `ENCLAIVE_LICENCE` as a plain env var.
- `secretName` set → renders `valueFrom.secretKeyRef`.
- Both set → `helm template` fails with `mutually exclusive`. Silent precedence would hide misconfigurations.
- Neither set → nothing rendered. Existing deployments that inject `ENCLAIVE_LICENCE` via `server.extraEnvironmentVars` or `server.extraSecretEnvironmentVars` keep working unchanged.

## Backward compatibility

100%. Defaults render nothing, so StatefulSet output is identical to the current chart for any existing values file.

## Tests

New bats unit tests:

- 5 standalone-mode tests (default, value, secretName, secretKey override, mutual-exclusion fail)
- 2 dev-mode tests
- 2 HA-mode tests

## Verification

Full bats unit suite run locally via the repo's Docker harness:

```
docker build -f test/docker/Dockerfile test/docker/ -t vhsm-helm-test
docker run --rm -v "$PWD:/test" vhsm-helm-test bats /test/test/unit
```

Result: **457 / 457 passing**. Zero failures, zero regressions. The 9 new licence tests plus 448 pre-existing tests all green. `helm lint` clean. `helm template --show-only` verified the rendered StatefulSet for all three modes (dev, standalone, HA).

## Test plan

- [ ] CI bats unit tests pass
- [ ] Reviewer confirms field shape aligns with vHSM product expectations