### PR TITLE
ci: add reusable KubeLinter workflow

### DIFF
--- a/.github/workflows/kube-linter.yml
+++ b/.github/workflows/kube-linter.yml
@@ -1,0 +1,13 @@
+name: KubeLinter
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  kube-linter:
+    uses: enclaive/security-workflows/.github/workflows/kube-linter.yml@main

--- a/.github/workflows/kube-linter.yml
+++ b/.github/workflows/kube-linter.yml
@@ -10,4 +10,4 @@ permissions:
 
 jobs:
   kube-linter:
-    uses: enclaive/security-workflows/.github/workflows/kube-linter.yml@main
+    uses: enclaive/security-workflows/.github/workflows/kube-linter.yml@af2103ab4882ac77dc58f4318af531bdfd813e7f # advisory kube-linter


### PR DESCRIPTION
Wires up the reusable kube-linter workflow from security-workflows, runs on PRs and main. Complements the existing chart-verifier and schema tests with best-practice checks on the rendered manifests.